### PR TITLE
Add slide-out sidebar for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,36 +35,42 @@
         </button>
     </div>
 </div>
-<div class="tabcontent active" id="interviews">
-    <div class="tab-inner">
-        <aside class="sidebar"></aside>
-        <main class="content"></main>
+    <div class="tabcontent active" id="interviews">
+        <div class="tab-inner">
+            <button class="sidebar-toggle" type="button">☰</button>
+            <aside class="sidebar"></aside>
+            <main class="content"></main>
+        </div>
     </div>
-</div>
-<div class="tabcontent" id="performances">
-    <div class="tab-inner">
-        <aside class="sidebar"></aside>
-        <main class="content"></main>
+    <div class="tabcontent" id="performances">
+        <div class="tab-inner">
+            <button class="sidebar-toggle" type="button">☰</button>
+            <aside class="sidebar"></aside>
+            <main class="content"></main>
+        </div>
     </div>
-</div>
-<div class="tabcontent" id="efter2023">
-    <div class="tab-inner">
-        <aside class="sidebar"></aside>
-        <main class="content"></main>
+    <div class="tabcontent" id="efter2023">
+        <div class="tab-inner">
+            <button class="sidebar-toggle" type="button">☰</button>
+            <aside class="sidebar"></aside>
+            <main class="content"></main>
+        </div>
     </div>
-</div>
-<div class="tabcontent" id="important">
-    <div class="tab-inner">
-        <aside class="sidebar"></aside>
-        <main class="content"></main>
+    <div class="tabcontent" id="important">
+        <div class="tab-inner">
+            <button class="sidebar-toggle" type="button">☰</button>
+            <aside class="sidebar"></aside>
+            <main class="content"></main>
+        </div>
     </div>
-</div>
-<div class="tabcontent" id="pdfs">
-    <div class="tab-inner">
-        <aside class="sidebar"></aside>
-        <main class="content"></main>
+    <div class="tabcontent" id="pdfs">
+        <div class="tab-inner">
+            <button class="sidebar-toggle" type="button">☰</button>
+            <aside class="sidebar"></aside>
+            <main class="content"></main>
+        </div>
     </div>
-</div>
+    <div class="overlay"></div>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,18 @@ document.addEventListener('DOMContentLoaded', () => {
 tag.src = "https://www.youtube.com/iframe_api";
 document.body.appendChild(tag);
 
+  document.querySelectorAll('.sidebar-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const sidebar = btn.parentElement.querySelector('.sidebar');
+      if (sidebar) {
+        sidebar.classList.add('open');
+        document.querySelector('.overlay').classList.add('show');
+        document.body.classList.add('sidebar-open');
+      }
+    });
+  });
+  document.querySelector('.overlay').addEventListener('click', closeSidebar);
+
 });
 
 const renderTabFromJson = async (tabId, jsonUrl) => {
@@ -43,6 +55,7 @@ console.log('videoID:', item.videoID);
   });
 
   setupScrollSpy(tabId);
+  setupSidebarLinks(tabId);
 };
 
 const convertTimeToSpan = text => text.replace(/(\d{1,2}):(\d{2})/g, (_, m, s) => `<span class="time-jump" data-time="${+m * 60 + +s}">${m}:${s}</span>`);
@@ -108,6 +121,21 @@ const renderPdfTab = async (tabId, jsonUrl) => {
     sidebar.append(link);
     if (!i) link.click();
   });
+  setupSidebarLinks(tabId);
+};
+
+const setupSidebarLinks = (tabId) => {
+  const sidebar = document.querySelector(`#${tabId} .sidebar`);
+  if (!sidebar) return;
+  sidebar.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', closeSidebar);
+  });
+};
+
+const closeSidebar = () => {
+  document.querySelectorAll('.sidebar').forEach(sb => sb.classList.remove('open'));
+  document.querySelector('.overlay').classList.remove('show');
+  document.body.classList.remove('sidebar-open');
 };
 
 

--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@ body {
   line-height: 1.8;
 }
 
+body.sidebar-open {
+  overflow: hidden;
+}
+
 header {
   background-color: #004080;
   color: white;
@@ -31,6 +35,15 @@ header {
   background-color: #f9f9f9;
   z-index: 999;
   padding-top: 10px;
+}
+
+.sidebar-toggle {
+  display: none;
+}
+
+.overlay {
+  display: none;
+  pointer-events: none;
 }
 
 .tabs {
@@ -276,9 +289,61 @@ iframe {
       flex-wrap: nowrap;
     }
 
-    .tab button {
-      flex: 0 0 auto;
-      font-size: 14px;
-      padding: 8px 12px;
-    }
+  .tab button {
+    flex: 0 0 auto;
+    font-size: 14px;
+    padding: 8px 12px;
+  }
+}
+
+@media (max-width: 768px) {
+  .sidebar-toggle {
+    display: block;
+    position: fixed;
+    top: 90px;
+    left: 10px;
+    z-index: 1002;
+    background: #004080;
+    color: #fff;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 250px;
+    max-width: 80%;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1001;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    z-index: 1000;
+    pointer-events: none;
+  }
+
+  .overlay.show {
+    display: block;
+    pointer-events: auto;
+  }
 }


### PR DESCRIPTION
## Summary
- add menu button for each tab and overlay in HTML
- implement slide-out styles for mobile view
- wire up sidebar toggle logic in JavaScript
- ensure sidebar is scrollable on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868e82a46008328b9f1741c1310cc02