### PR TITLE
Update sidebar to slide on all sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,13 +38,36 @@ header {
 }
 
 .sidebar-toggle {
-  display: none;
+  display: block;
+  position: fixed;
+  top: 90px;
+  left: 10px;
+  z-index: 1002;
+  background: #004080;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
   display: none;
+  z-index: 1000;
   pointer-events: none;
 }
+
+.overlay.show {
+  display: block;
+  pointer-events: auto;
+}
+
 
 .tabs {
   display: flex;
@@ -90,7 +113,7 @@ header {
 }
 
 .content {
-  flex: 0 0 50%;
+  flex: 1;
   min-width: 0;
 }
 
@@ -108,10 +131,28 @@ header {
   padding: 12px;
   border-radius: 6px;
   width: 500px;
-  position: sticky;
-  top: 200px;
-  height: fit-content;
+  max-width: 80%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
   flex-shrink: 0;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1001;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
+.sidebar.open {
+  transform: translateX(0);
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    width: 250px;
+  }
 }
 
 .sidebar a {
@@ -190,11 +231,6 @@ iframe {
 @media (max-width: 768px) {
   .tab-inner {
     flex-direction: column;
-  }
-  .sidebar {
-    width: 100%;
-    position: relative;
-    top: unset;
   }
 }
 
@@ -296,54 +332,3 @@ iframe {
   }
 }
 
-@media (max-width: 768px) {
-  .sidebar-toggle {
-    display: block;
-    position: fixed;
-    top: 90px;
-    left: 10px;
-    z-index: 1002;
-    background: #004080;
-    color: #fff;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-  }
-
-  .sidebar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 250px;
-    max-width: 80%;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
-    z-index: 1001;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    overscroll-behavior: contain;
-  }
-
-  .sidebar.open {
-    transform: translateX(0);
-  }
-
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-    display: none;
-    z-index: 1000;
-    pointer-events: none;
-  }
-
-  .overlay.show {
-    display: block;
-    pointer-events: auto;
-  }
-}


### PR DESCRIPTION
## Summary
- show sidebar toggle button at all widths
- make sidebar fixed with slide animation
- move overlay styles to global
- expand content area when sidebar is closed

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f510927c83288c59ca2a59a3936f