### PR TITLE
Render tab content with media

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -172,7 +172,8 @@ header .title {
   transform: translateX(0);
 }
 
-.sidebar a {
+.sidebar a,
+.sidebar button {
   display: block;
   padding: 0.625rem 0.75rem;
   margin-bottom: 0.5rem;
@@ -183,10 +184,21 @@ header .title {
   color: #004080;
   text-decoration: none;
   transition: background-color 0.2s, border-left 0.2s;
+  width: 100%;
+  text-align: left;
+}
+
+.sidebar button {
+  border: none;
+  background-color: #fff;
+  cursor: pointer;
+  font: inherit;
 }
 
 .sidebar a:hover,
-.sidebar a.active-link {
+.sidebar button:hover,
+.sidebar a.active-link,
+.sidebar button.active-link {
   background-color: #e6f0ff;
   border-left: 0.25rem solid #004080;
 }
@@ -202,6 +214,10 @@ header .title {
 }
 
 .text-content {
+  margin: 1rem 0;
+}
+
+.image-gallery {
   margin: 1rem 0;
 }
 
@@ -380,6 +396,18 @@ iframe {
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+.video-section video {
+  margin-top: 1rem;
+}
+
+.source {
+  margin-top: 1rem;
+}
+
+.pdf-panel {
+  width: 100%;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- render tab data with dedicated components for image galleries, video players, and PDF viewing so the content now mirrors the static site
- allow the sidebar to control PDF selection and keep state per tab while showing source attributions for each entry
- add styling for the new interactive elements so images, videos, and document viewers fit the layout

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d677980d48328a6a367dfd5ef71e2)