### PR TITLE
Fix data path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 
-const DATA_BASE_PATH = `${import.meta.env.BASE_URL}data`;
+// Using a relative path keeps the JSON fetches working no matter if the app is served
+// from the domain root, a subdirectory (like GitHub Pages) or even directly from the
+// file system. `import.meta.env.BASE_URL` becomes problematic in those scenarios
+// because it is resolved at build-time only.
+const DATA_BASE_PATH = './data';
 const ACTIVE_TAB_KEY = 'activeTab';
 const DEFAULT_TAB = 'Performance';
 


### PR DESCRIPTION
## Summary
- switch the JSON data fetches to use a relative path so they work regardless of the deployment base
- document why the change is needed to avoid future regressions

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd72be0388328bfc8b0ab2adfee9b)