### PR TITLE
Fix base path for custom domain deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,10 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/profile/',
+  // Using a relative base ensures the production bundle works whether the site is
+  // served from a custom domain root (keyvankianian.se) or the GitHub Pages
+  // project path (https://<username>.github.io/profile/).
+  base: './',
   server: {
     port: 5173,
     open: true


### PR DESCRIPTION
## Summary
- switch the Vite `base` option to a relative path so the production bundle works from either the custom domain root or the `/profile` project path on GitHub Pages

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd92d0d1483288cbc104c905af837)