### PR TITLE
Handle lack of IntersectionObserver support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,7 +52,11 @@ const useScrollSpy = (ids = [], options = {}, enabled = true) => {
   const { rootMargin = '-45% 0px -45% 0px', threshold = 0.1 } = options;
 
   useEffect(() => {
-    if (!enabled || typeof window === 'undefined') {
+    if (
+      !enabled ||
+      typeof window === 'undefined' ||
+      typeof window.IntersectionObserver === 'undefined'
+    ) {
       setActiveId(null);
       return undefined;
     }
@@ -63,7 +67,7 @@ const useScrollSpy = (ids = [], options = {}, enabled = true) => {
       return undefined;
     }
 
-    const observer = new IntersectionObserver(
+    const observer = new window.IntersectionObserver(
       (entries) => {
         const intersecting = entries.filter((entry) => entry.isIntersecting);
         if (intersecting.length) {


### PR DESCRIPTION
## Summary
- guard the scroll spy logic so it exits early when `IntersectionObserver` is not available
- instantiate the observer off of `window` to avoid runtime reference errors in older browsers

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de21f26cc8328ab5417432e45c66a)