### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,8 +1,8 @@
 header {
   background-color: #004080;
   color: white;
-  line-height: 1;
-  padding: 1.25rem;
+  line-height: 1.2;
+  padding: 0.75rem clamp(1rem, 4vw, 2.5rem);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11,30 +11,37 @@ header {
   left: 0;
   right: 0;
   z-index: 1000;
+  min-height: var(--header-height);
+  gap: 0.5rem;
 }
 
 header .logo {
   position: absolute;
-  left: 1.25rem;
-  font-size: 1rem;
+  left: clamp(1rem, 4vw, 2.5rem);
+  font-size: clamp(0.9rem, 2.5vw, 1.1rem);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 header .title {
-  font-size: 1.75rem;
+  font-size: clamp(1.25rem, 4vw, 1.9rem);
   margin: 0;
 }
 
 .tabs-container {
   position: fixed;
-  top: 4.3rem;
+  top: var(--header-height);
   left: 0;
   right: 0;
   background-color: #f9f9f9;
   z-index: 999;
-  padding: 1rem 0.625rem;
+  padding: 0.75rem clamp(0.75rem, 4vw, 1.5rem);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0.625rem;
+  gap: 0.75rem;
+  min-height: var(--tabs-height);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
 }
 
 .sidebar-toggle {
@@ -42,8 +49,9 @@ header .title {
   color: #fff;
   border: none;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.25rem;
+  border-radius: 0.35rem;
   cursor: pointer;
+  font-weight: 600;
 }
 
 .overlay {
@@ -52,10 +60,11 @@ header .title {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.55);
   display: none;
   z-index: 1000;
   pointer-events: none;
+  transition: opacity 0.3s ease;
 }
 
 .overlay.show {
@@ -65,10 +74,20 @@ header .title {
 
 .tabs {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
   flex: 1;
+  flex-wrap: nowrap;
+  gap: 0.35rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border-bottom: 0.125rem solid #ccc;
+  padding-bottom: 0.25rem;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  min-width: 0;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tablink {
@@ -76,13 +95,15 @@ header .title {
   border: 1px solid #ccc;
   border-bottom: none;
   border-radius: 0.375rem 0.375rem 0 0;
-  padding: 0.375rem 0.75rem;
-  margin: 0 0.25rem;
-  font-weight: bold;
+  padding: 0.5rem clamp(0.5rem, 2vw, 1rem);
+  font-weight: 600;
+  font-size: clamp(0.75rem, 2.5vw, 1rem);
   color: #004080;
   cursor: pointer;
-  box-shadow: 0 -0.125rem 0.3125rem rgba(0, 0, 0, 0.1);
-  transition: background-color 0.3s, color 0.3s;
+  box-shadow: 0 -0.125rem 0.3125rem rgba(0, 0, 0, 0.08);
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .tablink:hover {
@@ -96,15 +117,44 @@ header .title {
   box-shadow: none;
 }
 
-@media (max-width: 768px) {
-  .tablink {
-    font-size: 0.75rem;
-    padding: 0.375rem;
-    flex: 1 0 30%;
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
     text-align: center;
   }
 
+  header .logo {
+    position: static;
+  }
+
+  .tabs-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .tabs {
-    padding-top: 0;
+    width: 100%;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+}
+
+@media (min-width: 900px) {
+  .sidebar-toggle {
+    display: none;
+  }
+
+  .tabs-container {
+    flex-wrap: nowrap;
+  }
+
+  .tabs {
+    justify-content: center;
+    border-bottom: 0.125rem solid #ccc;
+  }
+
+  .overlay {
+    display: none !important;
+    pointer-events: none;
   }
 }

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -3,8 +3,14 @@
 }
 
 .pdf-frame {
-  width: 100rem;
-  max-width: 100%;
-  height: 100vh;
+  width: 100%;
+  max-width: 65rem;
+  height: 90vh;
   border: none;
+}
+
+@media (max-width: 768px) {
+  .pdf-frame {
+    height: 70vh;
+  }
 }

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -1,22 +1,26 @@
 .tabcontent {
   display: none;
-  padding: 20vh 10rem 1.875rem;
+  padding: calc(var(--header-height) + var(--tabs-height) + 1.5rem)
+    clamp(1.25rem, 6vw, 10rem)
+    2rem;
   width: 100%;
-  margin: auto;
+  margin: 0 auto;
 }
 
 .tabcontent.active {
-  display: flex;
+  display: block;
 }
 
 .tab-inner {
   display: flex;
   width: 100%;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 2.5rem;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1.5rem;
   margin-top: 1.25rem;
-  max-width: 100%;
+  max-width: 75rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .content {
@@ -32,8 +36,8 @@
   background-color: #f0f0f0;
   padding: 0.75rem;
   border-radius: 0.375rem;
-  width: min(31.25rem, 80vw);
-  max-width: 80%;
+  width: min(22rem, 85vw);
+  max-width: 90%;
   position: fixed;
   top: 0;
   left: 0;
@@ -87,7 +91,7 @@
   padding: 1.25rem;
   box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.05);
   margin-bottom: 1.875rem;
-  scroll-margin-top: 20vh;
+  scroll-margin-top: calc(var(--header-height) + var(--tabs-height) + 1rem);
 }
 
 .performance-item {
@@ -114,16 +118,8 @@
 }
 
 @media (max-width: 768px) {
-  .sidebar {
-    width: 80vw;
-  }
-
   .tabcontent {
-    padding: 20vh 2rem 1.875rem;
-  }
-
-  .tab-inner {
-    flex-direction: column;
+    padding: calc(var(--header-height) + var(--tabs-height) + 1rem) 1.25rem 1.5rem;
   }
 
   .performance-item {
@@ -137,5 +133,34 @@
   .performance-item iframe {
     width: 100% !important;
     height: auto;
+  }
+}
+
+@media (min-width: 900px) {
+  .tabcontent {
+    padding: calc(var(--header-height) + var(--tabs-height) + 2rem) clamp(2rem, 7vw, 10rem) 2.5rem;
+  }
+
+  .tab-inner {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 2.5rem;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: calc(var(--header-height) + var(--tabs-height) + 1rem);
+    left: auto;
+    bottom: auto;
+    transform: none;
+    width: min(22rem, 28vw);
+    max-width: 22rem;
+    box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.08);
+    height: fit-content;
+    max-height: calc(100vh - var(--header-height) - var(--tabs-height) - 2rem);
+  }
+
+  .sidebar.open {
+    transform: none;
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -4,6 +4,18 @@
   box-sizing: border-box;
 }
 
+:root {
+  --header-height: 4.5rem;
+  --tabs-height: 3.75rem;
+}
+
+@media (max-width: 600px) {
+  :root {
+    --header-height: 5.25rem;
+    --tabs-height: 4.25rem;
+  }
+}
+
 html {
   scroll-behavior: smooth;
 }
@@ -19,6 +31,12 @@ body {
 
 body.sidebar-open {
   overflow: hidden;
+}
+
+@media (min-width: 900px) {
+  body.sidebar-open {
+    overflow: auto;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- retune the fixed header, tab strip and overlay behaviors so that navigation is touch-friendly, scrollable and sized for phones while remaining tidy on desktop
- rework the tab panel layout to use CSS variables for offsets, stack content vertically on small screens and surface the sidebar as a sticky column on larger displays
- scale the embedded PDF viewport height responsively

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df0a32d28832882210f5f71dac1f7)