### PR TITLE
Refresh profile styling

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,8 +1,8 @@
 header {
-  background-color: #004080;
+  background: linear-gradient(120deg, #0f172a, #1d3a8a);
   color: white;
   line-height: 1.2;
-  padding: 0.75rem clamp(1rem, 4vw, 2.5rem);
+  padding: 0.85rem clamp(1rem, 3vw, 2.5rem);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -12,20 +12,23 @@ header {
   right: 0;
   z-index: 1000;
   min-height: var(--header-height);
-  gap: 0.5rem;
+  gap: 0.75rem;
+  box-shadow: var(--shadow-soft);
 }
 
 header .logo {
   position: absolute;
   left: clamp(1rem, 4vw, 2.5rem);
-  font-size: clamp(0.9rem, 2.5vw, 1.1rem);
+  font-size: clamp(0.85rem, 2vw, 1rem);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.15em;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 header .title {
-  font-size: clamp(1.25rem, 4vw, 1.9rem);
+  font-size: clamp(1.5rem, 4vw, 2.4rem);
   margin: 0;
+  font-weight: 600;
 }
 
 .tabs-container {
@@ -33,25 +36,29 @@ header .title {
   top: var(--header-height);
   left: 0;
   right: 0;
-  background-color: #f9f9f9;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
   z-index: 999;
-  padding: 0.75rem clamp(0.75rem, 4vw, 1.5rem);
+  padding: 0.85rem clamp(0.75rem, 4vw, 2rem);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.85rem;
   min-height: var(--tabs-height);
-  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+  box-shadow: 0 1rem 1.5rem rgba(13, 20, 43, 0.1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .sidebar-toggle {
-  background: #004080;
+  background: var(--color-primary);
   color: #fff;
   border: none;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.35rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
   cursor: pointer;
   font-weight: 600;
+  letter-spacing: 0.03em;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
 }
 
 .overlay {
@@ -60,7 +67,7 @@ header .title {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(13, 20, 43, 0.7);
   display: none;
   z-index: 1000;
   pointer-events: none;
@@ -79,7 +86,6 @@ header .title {
   gap: 0.35rem;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  border-bottom: 0.125rem solid #ccc;
   padding-bottom: 0.25rem;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -91,36 +97,37 @@ header .title {
 }
 
 .tablink {
-  background-color: white;
-  border: 1px solid #ccc;
-  border-bottom: none;
-  border-radius: 0.375rem 0.375rem 0 0;
-  padding: 0.5rem clamp(0.5rem, 2vw, 1rem);
+  background-color: rgba(255, 255, 255, 0.85);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.45rem clamp(0.5rem, 2vw, 1.25rem);
   font-weight: 600;
   font-size: clamp(0.75rem, 2.5vw, 1rem);
-  color: #004080;
+  color: var(--color-primary);
   cursor: pointer;
-  box-shadow: 0 -0.125rem 0.3125rem rgba(0, 0, 0, 0.08);
-  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s, transform 0.2s;
   flex: 0 0 auto;
   white-space: nowrap;
 }
 
 .tablink:hover {
-  background-color: #f0f0f0;
+  transform: translateY(-2px);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.3);
 }
 
 .tablink.active {
-  background-color: #004080;
+  background-color: var(--color-primary);
   color: white;
-  border-color: #004080;
-  box-shadow: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
 }
 
 @media (max-width: 600px) {
   header {
     flex-direction: column;
     text-align: center;
+    padding-top: 1rem;
   }
 
   header .logo {
@@ -134,7 +141,6 @@ header .title {
 
   .tabs {
     width: 100%;
-    border-bottom: none;
     padding-bottom: 0;
   }
 }
@@ -150,7 +156,6 @@ header .title {
 
   .tabs {
     justify-content: center;
-    border-bottom: 0.125rem solid #ccc;
   }
 
   .overlay {

--- a/src/components/ImageGallery/ImageGallery.css
+++ b/src/components/ImageGallery/ImageGallery.css
@@ -1,49 +1,53 @@
 .image-gallery {
-  margin: 1rem 0;
+  margin: 1.25rem 0;
 }
 
 .main-image {
   width: 100%;
-  border-radius: 0.5rem;
-  margin-bottom: 0.5rem;
+  border-radius: 1rem;
+  margin-bottom: 0.75rem;
   max-height: 70vh;
-  object-fit: contain;
+  object-fit: cover;
+  box-shadow: var(--shadow-soft);
 }
 
 .thumbnail-row {
   display: flex;
-  gap: 0.375rem;
-  margin-top: 0.625rem;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   overflow-x: auto;
-  padding: 0.375rem;
-  border: 1px solid #ccc;
-  border-radius: 0.25rem;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.05);
 }
 
 .thumbnail {
-  width: 5rem;
-  height: 3.75rem;
+  width: 4.25rem;
+  height: 3.2rem;
   object-fit: cover;
-  border-radius: 0.25rem;
+  border-radius: 0.5rem;
   cursor: pointer;
-  transition: transform 0.2s, border 0.2s;
-  border: 0.125rem solid transparent;
+  transition: transform 0.2s, border 0.2s, opacity 0.2s;
+  border: 2px solid transparent;
+  opacity: 0.8;
 }
 
 .thumbnail:hover {
-  transform: scale(1.05);
+  transform: translateY(-2px);
+  opacity: 1;
 }
 
 .thumbnail.selected {
-  border: 0.125rem solid #004080;
+  border-color: var(--color-accent);
+  opacity: 1;
 }
 
 @media (max-width: 768px) {
   .thumbnail-row {
     flex-wrap: wrap;
     justify-content: center;
-    margin: 0.625rem 0.5rem 0;
+    border-radius: 1rem;
   }
 }

--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -5,12 +5,15 @@
 .pdf-frame {
   width: 100%;
   max-width: 65rem;
-  height: 90vh;
+  min-height: clamp(60vh, 70vw, 85vh);
   border: none;
+  border-radius: 1rem;
+  box-shadow: var(--shadow-soft);
+  background: #fff;
 }
 
 @media (max-width: 768px) {
   .pdf-frame {
-    height: 70vh;
+    min-height: 70vh;
   }
 }

--- a/src/components/SourceAttribution/SourceAttribution.css
+++ b/src/components/SourceAttribution/SourceAttribution.css
@@ -1,3 +1,11 @@
 .source {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed rgba(15, 23, 42, 0.15);
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.source a {
+  font-weight: 600;
 }

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -1,8 +1,8 @@
 .tabcontent {
   display: none;
   padding: calc(var(--header-height) + var(--tabs-height) + 1.5rem)
-    clamp(1.25rem, 6vw, 10rem)
-    2rem;
+    clamp(1.25rem, 6vw, 8rem)
+    3rem;
   width: 100%;
   margin: 0 auto;
 }
@@ -17,8 +17,8 @@
   flex-direction: column;
   align-items: stretch;
   gap: 1.5rem;
-  margin-top: 1.25rem;
-  max-width: 75rem;
+  margin-top: 1.5rem;
+  max-width: 80rem;
   margin-left: auto;
   margin-right: auto;
 }
@@ -26,16 +26,15 @@
 .content {
   flex: 1;
   min-width: 0;
-  padding: 0;
-  margin: 0;
   display: flex;
   flex-direction: column;
+  gap: 1.75rem;
 }
 
 .sidebar {
-  background-color: #f0f0f0;
-  padding: 0.75rem;
-  border-radius: 0.375rem;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 1rem;
+  border-radius: var(--radius);
   width: min(22rem, 85vw);
   max-width: 90%;
   position: fixed;
@@ -50,95 +49,90 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
+  box-shadow: var(--shadow-soft);
 }
 
 .sidebar.open {
   transform: translateX(0);
 }
 
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+}
+
 .sidebar-link {
   display: block;
-  padding: 0.625rem 0.75rem;
-  margin-bottom: 0.5rem;
-  background-color: #fff;
-  border-left: 0.25rem solid transparent;
-  border-radius: 0.25rem;
-  font-weight: bold;
-  color: #004080;
+  padding: 0.75rem 0.85rem;
+  margin-bottom: 0.55rem;
+  background-color: rgba(255, 255, 255, 0.75);
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  font-weight: 600;
+  color: var(--color-primary);
   text-decoration: none;
-  transition: background-color 0.2s, border-left 0.2s;
+  transition: background-color 0.2s, border 0.2s, transform 0.2s;
   width: 100%;
   text-align: left;
 }
 
 .sidebar button.sidebar-link {
   border: none;
-  background-color: #fff;
+  background-color: rgba(255, 255, 255, 0.9);
   cursor: pointer;
   font: inherit;
 }
 
 .sidebar-link:hover,
 .sidebar-link.active-link {
-  background-color: #e6f0ff;
-  border-left: 0.25rem solid #004080;
+  background-color: rgba(15, 23, 42, 0.08);
+  border-color: rgba(15, 23, 42, 0.2);
+  transform: translateX(2px);
 }
 
 .performance-item,
-.video-item {
-  background-color: white;
-  border-radius: 0.5rem;
-  padding: 1.25rem;
-  box-shadow: 0 0 0.625rem rgba(0, 0, 0, 0.05);
-  margin-bottom: 1.875rem;
+.video-item,
+.pdf-panel {
+  background-color: var(--color-surface);
+  border-radius: 1rem;
+  padding: clamp(1.25rem, 2.5vw, 2rem);
+  box-shadow: var(--shadow-soft);
+  margin: 0;
   scroll-margin-top: calc(var(--header-height) + var(--tabs-height) + 1rem);
-}
-
-.performance-item {
-  padding: 0;
-  margin: 0 0 1rem;
-  box-shadow: none;
-  flex: 1;
+  border: 1px solid rgba(255, 255, 255, 0.4);
 }
 
 .performance-item h2 {
   margin-top: 0;
-}
-
-.performance-item video,
-.performance-item img,
-.performance-item iframe {
-  width: 100%;
-  border-radius: 0.5rem;
-  margin-top: 0.625rem;
+  font-size: clamp(1.25rem, 3vw, 1.9rem);
 }
 
 .text-content {
-  margin: 1rem 0;
+  margin: 1rem 0 1.5rem;
+  color: var(--color-muted);
+}
+
+.text-content p {
+  margin-bottom: 0.9rem;
 }
 
 @media (max-width: 768px) {
   .tabcontent {
-    padding: calc(var(--header-height) + var(--tabs-height) + 1rem) 1.25rem 1.5rem;
+    padding: calc(var(--header-height) + var(--tabs-height) + 1rem) 1.15rem 2rem;
   }
 
   .performance-item {
-    padding: 0.625rem;
+    padding: 1rem;
   }
 
   .performance-item h2 {
-    font-size: 1.125rem;
-  }
-
-  .performance-item iframe {
-    width: 100% !important;
-    height: auto;
+    font-size: 1.25rem;
   }
 }
 
 @media (min-width: 900px) {
   .tabcontent {
-    padding: calc(var(--header-height) + var(--tabs-height) + 2rem) clamp(2rem, 7vw, 10rem) 2.5rem;
+    padding: calc(var(--header-height) + var(--tabs-height) + 2rem) clamp(2rem, 7vw, 10rem) 3rem;
   }
 
   .tab-inner {
@@ -155,7 +149,6 @@
     transform: none;
     width: min(22rem, 28vw);
     max-width: 22rem;
-    box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.08);
     height: fit-content;
     max-height: calc(100vh - var(--header-height) - var(--tabs-height) - 2rem);
   }

--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -1,14 +1,23 @@
 .video-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.video-section video,
+.video-container {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(22, 35, 71, 0.08);
+  box-shadow: var(--shadow-soft);
+  background: #000;
 }
 
 .video-container {
   position: relative;
   padding-bottom: 56.25%;
   height: 0;
-  overflow: hidden;
   max-width: 100%;
 }
 
@@ -24,13 +33,15 @@
 
 .video-section video {
   width: 100%;
-  border-radius: 0.5rem;
-  margin-top: 1rem;
+  margin: 0;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  background: #000;
 }
 
 .video-frame {
   width: 100%;
-  height: 60vh;
+  height: min(60vh, 32rem);
   max-width: 100%;
   border: none;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
 *,
 *::before,
 *::after {
@@ -6,7 +8,16 @@
 
 :root {
   --header-height: 4.5rem;
-  --tabs-height: 3.75rem;
+  --tabs-height: 3.5rem;
+  --color-primary: #162347;
+  --color-primary-strong: #0d142b;
+  --color-accent: #f97316;
+  --color-surface: #ffffff;
+  --color-muted: #5f6d7e;
+  --color-border: #e3e8f2;
+  --color-background: #f5f7fb;
+  --radius: 0.75rem;
+  --shadow-soft: 0 20px 35px rgba(13, 20, 43, 0.15);
 }
 
 @media (max-width: 600px) {
@@ -21,12 +32,14 @@ html {
 }
 
 body {
-  font-family: Arial, sans-serif;
-  background-color: #f9f9f9;
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, rgba(249, 115, 22, 0.08), transparent 50%),
+    var(--color-background);
   margin: 0;
   padding: 0;
-  color: #333;
-  line-height: 1.8;
+  color: var(--color-primary-strong);
+  line-height: 1.7;
+  min-height: 100vh;
 }
 
 body.sidebar-open {
@@ -39,9 +52,33 @@ body.sidebar-open {
   }
 }
 
+img,
+video,
+iframe {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.2em;
+}
+
+a:hover {
+  text-decoration-style: wavy;
+}
+
+p,
+.caption {
+  color: var(--color-muted);
+  font-size: clamp(0.95rem, 1.9vw, 1.05rem);
+}
+
 @media (max-width: 768px) {
-  .caption,
-  p {
-    font-size: 0.875rem;
+  p,
+  .caption {
+    font-size: 0.9rem;
   }
 }


### PR DESCRIPTION
## Summary
- modernize the global palette, typography, and layout spacing for the profile experience
- refresh the header, tabs, sidebar, and content cards with consistent shadows, rounded corners, and improved hierarchy
- refine media presentation for the galleries, video embeds, and PDF viewer so assets scale predictably

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df2c34b1483288ed6e9c46cfc20da)