### PR TITLE
Add print support for profile tabs

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -16,6 +16,26 @@ header {
   box-shadow: var(--shadow-soft);
 }
 
+header .print-button {
+  margin-left: auto;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
+}
+
+header .print-button:hover,
+header .print-button:focus-visible {
+  background: rgba(255, 255, 255, 0.3);
+  outline: none;
+}
+
 header .logo {
   position: absolute;
   left: clamp(1rem, 4vw, 2.5rem);
@@ -134,6 +154,11 @@ header .title {
     position: static;
   }
 
+  header .print-button {
+    width: 100%;
+    margin-left: 0;
+  }
+
   .tabs-container {
     flex-direction: column;
     align-items: stretch;
@@ -142,6 +167,20 @@ header .title {
   .tabs {
     width: 100%;
     padding-bottom: 0;
+  }
+}
+
+@media print {
+  body {
+    background: #fff;
+  }
+
+  header,
+  .tabs-container,
+  .sidebar-toggle,
+  .overlay,
+  .sidebar {
+    display: none !important;
   }
 }
 

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -42,11 +42,19 @@ const App = () => {
   const toggleSidebar = () => setSidebarOpen((prev) => !prev);
   const closeSidebar = () => setSidebarOpen(false);
 
+  const handlePrint = () => {
+    if (typeof window === 'undefined') return;
+    window.print();
+  };
+
   return (
     <>
       <header>
         <span className="logo">Keyvan Kianian</span>
         <h1 className="title">Profile</h1>
+        <button type="button" className="print-button" onClick={handlePrint}>
+          Print page
+        </button>
       </header>
 
       <div className="tabs-container">

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -157,3 +157,34 @@
     transform: none;
   }
 }
+
+@media print {
+  .tabcontent {
+    display: none !important;
+    padding: 0;
+    margin: 0 auto;
+  }
+
+  .tabcontent.active {
+    display: block !important;
+  }
+
+  .tab-inner {
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 100%;
+    margin: 0 auto;
+  }
+
+  .content {
+    width: 100%;
+  }
+
+  .performance-item,
+  .video-item,
+  .pdf-panel {
+    box-shadow: none;
+    border: 1px solid rgba(15, 23, 42, 0.15);
+    page-break-inside: avoid;
+  }
+}


### PR DESCRIPTION
## Summary
- add a print button to the header so every tab can be printed on demand
- add print-specific styles to hide navigation UI and ensure the active tab renders cleanly on paper

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df53df86c8328a8c1410f87293c10)