### PR TITLE
Ensure gallery images stay fully visible

### DIFF
--- a/src/components/ImageGallery/ImageGallery.css
+++ b/src/components/ImageGallery/ImageGallery.css
@@ -7,7 +7,8 @@
   border-radius: 1rem;
   margin-bottom: 0.75rem;
   max-height: 70vh;
-  object-fit: cover;
+  object-fit: contain;
+  background: rgba(15, 23, 42, 0.06);
   box-shadow: var(--shadow-soft);
 }
 


### PR DESCRIPTION
## Summary
- ensure the main gallery image keeps its entire contents in view by switching to `object-fit: contain`
- add a subtle background to avoid harsh edges when portrait assets no longer fill the frame

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df621f6ec8328a26963cd0b67a3af)