### PR TITLE
Improve PDF responsiveness on mobile

### DIFF
--- a/src/components/PdfViewer/PdfViewer.jsx
+++ b/src/components/PdfViewer/PdfViewer.jsx
@@ -1,16 +1,30 @@
 import './PdfViewer.css';
 
+const buildPdfSrc = (src) => {
+  if (!src) return '';
+
+  const [base, rawHash = ''] = src.split('#');
+  const params = new URLSearchParams(rawHash);
+  params.set('toolbar', '0');
+  params.set('view', 'FitH');
+  params.set('zoom', 'page-width');
+
+  return `${base}#${params.toString()}`;
+};
+
 const PdfViewer = ({ item }) => {
   if (!item) {
     return <p>Välj ett dokument från listan för att visa det här.</p>;
   }
+
+  const pdfSrc = buildPdfSrc(item.pdf);
 
   return (
     <article className="performance-item pdf-panel" id={item.id}>
       <h2>{item.title}</h2>
       {item.caption && <p>{item.caption}</p>}
       {item.pdf && (
-        <iframe className="pdf-frame" src={`${item.pdf}#toolbar=0`} title={item.title} loading="lazy"></iframe>
+        <iframe className="pdf-frame" src={pdfSrc} title={item.title} loading="lazy"></iframe>
       )}
       {item.pdf && (
         <p>


### PR DESCRIPTION
## Summary
- normalize embedded PDF URLs so they request toolbar-free, page-width rendering
- ensure the document iframe uses the normalized URL so PDFs fit the mobile viewport without horizontal scrolling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df91879b483289d8c842b7110fde9)