### PR TITLE
Add bilingual Persian/Swedish support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,5 +16,19 @@ export default [
       'no-unused-vars': ['warn', { args: 'none', ignoreRestSiblings: true }],
       'no-console': ['warn', { allow: ['error'] }]
     }
+  },
+  {
+    files: ['**/*.cjs'],
+    languageOptions: {
+      globals: globals.node,
+      sourceType: 'commonjs'
+    }
+  },
+  {
+    files: ['**/vite.config.js', '**/eslint.config.js'],
+    languageOptions: {
+      globals: globals.node,
+      sourceType: 'module'
+    }
   }
 ];

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 module.exports = {
   singleQuote: true,
   semi: true,

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -16,6 +16,13 @@ header {
   box-shadow: var(--shadow-soft);
 }
 
+.title-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 header .print-button {
   background: rgba(255, 255, 255, 0.15);
   color: #fff;
@@ -50,6 +57,38 @@ header .title {
   font-weight: 600;
   text-align: center;
   justify-self: center;
+}
+
+.language-switch {
+  display: inline-flex;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.1rem;
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
+}
+
+.language-button {
+  background: transparent;
+  color: white;
+  border: none;
+  padding: 0.35rem 0.65rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.language-button.active {
+  background: rgba(255, 255, 255, 0.85);
+  color: #0f172a;
+}
+
+.language-button:not(.active):hover,
+.language-button:not(.active):focus-visible {
+  background: rgba(255, 255, 255, 0.25);
+  outline: none;
 }
 
 .tabs-container {
@@ -142,6 +181,22 @@ header .title {
   color: white;
   border-color: var(--color-primary);
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
+}
+
+[dir='rtl'] header {
+  direction: rtl;
+  grid-template-columns: auto 1fr auto;
+}
+
+[dir='rtl'] .tabs-container,
+[dir='rtl'] .tabs {
+  direction: rtl;
+}
+
+[dir='rtl'] .sidebar-toggle,
+[dir='rtl'] .tablink,
+[dir='rtl'] .print-button {
+  font-family: inherit;
 }
 
 @media (max-width: 600px) {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,15 +4,56 @@ import './App.css';
 
 const DATA_BASE_PATH = './data';
 const ACTIVE_TAB_KEY = 'activeTab';
+const LANGUAGE_KEY = 'language';
 const DEFAULT_TAB = 'Performance';
+const DEFAULT_LANGUAGE = 'sv';
 
 const tabs = [
-  { id: 'artiklar', label: 'Artiklar', dataPath: `${DATA_BASE_PATH}/artiklar.json` },
-  { id: 'bilder', label: 'Bilder', dataPath: `${DATA_BASE_PATH}/bilder.json` },
-  { id: 'Performance', label: 'Performance', dataPath: `${DATA_BASE_PATH}/Performance.json` },
-  { id: 'interview', label: 'Interview', dataPath: `${DATA_BASE_PATH}/interview.json` },
-  { id: 'pdfs', label: 'Dokuments', dataPath: `${DATA_BASE_PATH}/pdfs.json` }
+  {
+    id: 'artiklar',
+    label: { sv: 'Artiklar', fa: 'مقالات' },
+    dataPath: { sv: `${DATA_BASE_PATH}/artiklar.json`, fa: `${DATA_BASE_PATH}/artiklar.json` }
+  },
+  {
+    id: 'bilder',
+    label: { sv: 'Bilder', fa: 'تصاویر' },
+    dataPath: { sv: `${DATA_BASE_PATH}/bilder.json`, fa: `${DATA_BASE_PATH}/bilder.json` }
+  },
+  {
+    id: 'Performance',
+    label: { sv: 'Performance', fa: 'اجراها' },
+    dataPath: { sv: `${DATA_BASE_PATH}/Performance.json`, fa: `${DATA_BASE_PATH}/Performance.json` }
+  },
+  {
+    id: 'interview',
+    label: { sv: 'Interview', fa: 'مصاحبه‌ها' },
+    dataPath: { sv: `${DATA_BASE_PATH}/interview.json`, fa: `${DATA_BASE_PATH}/interview.json` }
+  },
+  {
+    id: 'pdfs',
+    label: { sv: 'Dokuments', fa: 'اسناد' },
+    dataPath: { sv: `${DATA_BASE_PATH}/pdfs.json`, fa: `${DATA_BASE_PATH}/pdfs.json` }
+  }
 ];
+
+const translations = {
+  sv: {
+    logo: 'Keyvan Kianian',
+    title: 'Profil',
+    printButton: 'Skriv ut sidan',
+    allList: '☰ Alla listor',
+    languageLabel: 'Välj språk',
+    languageNames: { sv: 'Svenska', fa: 'فارسی' }
+  },
+  fa: {
+    logo: 'کیوان کیانیان',
+    title: 'پروفایل',
+    printButton: 'چاپ صفحه',
+    allList: '☰ فهرست کامل',
+    languageLabel: 'انتخاب زبان',
+    languageNames: { sv: 'سوئدی', fa: 'فارسی' }
+  }
+};
 
 const App = () => {
   const [activeTab, setActiveTab] = useState(() => {
@@ -22,12 +63,27 @@ const App = () => {
     const saved = localStorage.getItem(ACTIVE_TAB_KEY);
     return tabs.some((tab) => tab.id === saved) ? saved : DEFAULT_TAB;
   });
+  const [language, setLanguage] = useState(() => {
+    if (typeof window === 'undefined') return DEFAULT_LANGUAGE;
+    const saved = localStorage.getItem(LANGUAGE_KEY);
+    if (saved && translations[saved]) return saved;
+    if (typeof navigator !== 'undefined' && navigator.language?.startsWith('fa')) return 'fa';
+    return DEFAULT_LANGUAGE;
+  });
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     localStorage.setItem(ACTIVE_TAB_KEY, activeTab);
   }, [activeTab]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(LANGUAGE_KEY, language);
+    document.documentElement.lang = language;
+    document.documentElement.dir = language === 'fa' ? 'rtl' : 'ltr';
+    document.body.dir = language === 'fa' ? 'rtl' : 'ltr';
+  }, [language]);
 
   useEffect(() => {
     document.body.classList.toggle('sidebar-open', sidebarOpen);
@@ -47,19 +103,40 @@ const App = () => {
     window.print();
   };
 
+  const handleLanguageChange = (nextLanguage) => {
+    if (!translations[nextLanguage]) return;
+    setLanguage(nextLanguage);
+  };
+
+  const localizedStrings = translations[language] ?? translations[DEFAULT_LANGUAGE];
+
   return (
     <>
       <header>
-        <span className="logo">Keyvan Kianian</span>
-        <h1 className="title">Profile</h1>
+        <span className="logo">{localizedStrings.logo}</span>
+        <div className="title-group">
+          <h1 className="title">{localizedStrings.title}</h1>
+          <div className="language-switch" aria-label={localizedStrings.languageLabel}>
+            {Object.keys(translations).map((langKey) => (
+              <button
+                key={langKey}
+                type="button"
+                className={`language-button ${language === langKey ? 'active' : ''}`}
+                onClick={() => handleLanguageChange(langKey)}
+              >
+                {localizedStrings.languageNames[langKey] ?? langKey.toUpperCase()}
+              </button>
+            ))}
+          </div>
+        </div>
         <button type="button" className="print-button" onClick={handlePrint}>
-          Print page
+          {localizedStrings.printButton}
         </button>
       </header>
 
       <div className="tabs-container">
         <button className="sidebar-toggle" type="button" onClick={toggleSidebar}>
-          ☰ All List
+          {localizedStrings.allList}
         </button>
         <div className="tabs">
           {tabs.map((tab) => (
@@ -69,7 +146,9 @@ const App = () => {
               className={`tablink ${tab.id === activeTab ? 'active' : ''}`}
               onClick={() => handleTabClick(tab.id)}
             >
-              {tab.label}
+              {typeof tab.label === 'string'
+                ? tab.label
+                : tab.label[language] || tab.label[DEFAULT_LANGUAGE]}
             </button>
           ))}
         </div>
@@ -82,6 +161,7 @@ const App = () => {
           isActive={tab.id === activeTab}
           isSidebarOpen={sidebarOpen}
           closeSidebar={closeSidebar}
+          language={language}
         />
       ))}
 

--- a/src/components/ImageGallery/ImageGallery.jsx
+++ b/src/components/ImageGallery/ImageGallery.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import './ImageGallery.css';
 
-const ImageGallery = ({ images, title }) => {
+const fallbackStrings = {
+  galleryImageAlt: (itemTitle, index) => `${itemTitle || 'Gallery'} – bild ${index}`,
+  galleryPreviewAlt: (itemTitle, index) => `${itemTitle || 'Gallery'} – förhandsvisning ${index}`
+};
+
+const ImageGallery = ({ images, title, language, strings }) => {
   const normalized = useMemo(() => {
     if (!images) return [];
     if (Array.isArray(images)) return images.filter(Boolean);
@@ -16,10 +21,16 @@ const ImageGallery = ({ images, title }) => {
   if (!normalized.length) return null;
 
   const activeImage = normalized[Math.min(activeIndex, normalized.length - 1)];
+  const copy = strings || fallbackStrings;
 
   return (
     <figure className="image-gallery">
-      <img src={activeImage} alt={`${title || 'Gallery'} – bild ${activeIndex + 1}`} className="main-image" />
+      <img
+        src={activeImage}
+        alt={copy.galleryImageAlt?.(title, activeIndex + 1) || `${title || 'Gallery'} – bild ${activeIndex + 1}`}
+        className="main-image"
+        dir={language === 'fa' ? 'rtl' : 'ltr'}
+      />
       {normalized.length > 1 && (
         <div className="thumbnail-row" role="list">
           {normalized.map((src, index) => (
@@ -27,7 +38,9 @@ const ImageGallery = ({ images, title }) => {
               key={src}
               role="listitem"
               src={src}
-              alt={`${title || 'Gallery'} – förhandsvisning ${index + 1}`}
+              alt={
+                copy.galleryPreviewAlt?.(title, index + 1) || `${title || 'Gallery'} – förhandsvisning ${index + 1}`
+              }
               className={`thumbnail ${index === activeIndex ? 'selected' : ''}`}
               onClick={() => setActiveIndex(index)}
             />

--- a/src/components/PdfViewer/PdfViewer.jsx
+++ b/src/components/PdfViewer/PdfViewer.jsx
@@ -12,15 +12,23 @@ const buildPdfSrc = (src) => {
   return `${base}#${params.toString()}`;
 };
 
-const PdfViewer = ({ item }) => {
+const fallbackStrings = {
+  choosePdf: 'Välj ett dokument från listan för att visa det här.',
+  openPdfInNewTab: 'Öppna dokumentet i en ny flik'
+};
+
+const PdfViewer = ({ item, language, strings }) => {
+  const copy = strings || fallbackStrings;
+  const direction = language === 'fa' ? 'rtl' : 'ltr';
+
   if (!item) {
-    return <p>Välj ett dokument från listan för att visa det här.</p>;
+    return <p>{copy.choosePdf}</p>;
   }
 
   const pdfSrc = buildPdfSrc(item.pdf);
 
   return (
-    <article className="performance-item pdf-panel" id={item.id}>
+    <article className="performance-item pdf-panel" id={item.id} dir={direction}>
       <h2>{item.title}</h2>
       {item.caption && <p>{item.caption}</p>}
       {item.pdf && (
@@ -29,7 +37,7 @@ const PdfViewer = ({ item }) => {
       {item.pdf && (
         <p>
           <a href={item.pdf} target="_blank" rel="noreferrer">
-            Öppna dokumentet i en ny flik
+            {copy.openPdfInNewTab}
           </a>
         </p>
       )}

--- a/src/components/SourceAttribution/SourceAttribution.jsx
+++ b/src/components/SourceAttribution/SourceAttribution.jsx
@@ -1,11 +1,16 @@
 import './SourceAttribution.css';
 
-const SourceAttribution = ({ source }) => {
+const fallbackStrings = { sourceLabel: 'Källa' };
+
+const SourceAttribution = ({ source, language, strings }) => {
   if (!source?.url) return null;
 
+  const copy = strings || fallbackStrings;
+  const direction = language === 'fa' ? 'rtl' : 'ltr';
+
   return (
-    <p className="source">
-      <strong>{source.label || 'Källa'}:</strong>{' '}
+    <p className="source" dir={direction}>
+      <strong>{source.label || copy.sourceLabel}:</strong>{' '}
       <a href={source.url} target="_blank" rel="noreferrer">
         {source.url}
       </a>

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -52,6 +52,16 @@
   box-shadow: var(--shadow-soft);
 }
 
+[dir='rtl'] .sidebar {
+  left: auto;
+  right: 0;
+  transform: translateX(100%);
+}
+
+[dir='rtl'] .sidebar.open {
+  transform: translateX(0);
+}
+
 .sidebar.open {
   transform: translateX(0);
 }
@@ -76,6 +86,10 @@
   text-align: left;
 }
 
+[dir='rtl'] .sidebar-link {
+  text-align: right;
+}
+
 .sidebar button.sidebar-link {
   border: none;
   background-color: rgba(255, 255, 255, 0.9);
@@ -88,6 +102,11 @@
   background-color: rgba(15, 23, 42, 0.08);
   border-color: rgba(15, 23, 42, 0.2);
   transform: translateX(2px);
+}
+
+[dir='rtl'] .sidebar-link:hover,
+[dir='rtl'] .sidebar-link.active-link {
+  transform: translateX(-2px);
 }
 
 .performance-item,

--- a/src/components/TabPanel/TabPanel.jsx
+++ b/src/components/TabPanel/TabPanel.jsx
@@ -5,6 +5,37 @@ import SourceAttribution from '../SourceAttribution/SourceAttribution';
 import VideoPlayer from '../VideoPlayer/VideoPlayer';
 import './TabPanel.css';
 
+const textContent = {
+  sv: {
+    loadingList: 'Laddar lista…',
+    loadError: 'Misslyckades med att ladda innehållet.',
+    loadingContent: 'Laddar innehåll…',
+    renderError: (label) => `Kunde inte visa ${label} än.`,
+    openPdf: 'Öppna PDF-dokument',
+    sourceLabel: 'Källa',
+    choosePdf: 'Välj ett dokument från listan för att visa det här.',
+    openPdfInNewTab: 'Öppna dokumentet i en ny flik',
+    galleryImageAlt: (title, index) => `${title || 'Gallery'} – bild ${index}`,
+    galleryPreviewAlt: (title, index) => `${title || 'Gallery'} – förhandsvisning ${index}`,
+    videoTitle: (title) => title || 'Video från YouTube',
+    videoFallback: 'Din webbläsare stödjer inte video-taggen.'
+  },
+  fa: {
+    loadingList: 'در حال بارگذاری فهرست…',
+    loadError: 'بارگذاری محتوا انجام نشد.',
+    loadingContent: 'در حال بارگذاری محتوا…',
+    renderError: (label) => `فعلاً نمی‌توان ${label} را نمایش داد.`,
+    openPdf: 'باز کردن فایل PDF',
+    sourceLabel: 'منبع',
+    choosePdf: 'برای نمایش، یک سند از فهرست انتخاب کنید.',
+    openPdfInNewTab: 'باز کردن سند در زبانه جدید',
+    galleryImageAlt: (title, index) => `${title || 'گالری'} – تصویر ${index}`,
+    galleryPreviewAlt: (title, index) => `${title || 'گالری'} – پیش‌نمایش ${index}`,
+    videoTitle: (title) => title || 'ویدیو از یوتیوب',
+    videoFallback: 'مرورگر شما از پخش ویدیو پشتیبانی نمی‌کند.'
+  }
+};
+
 const useJsonData = (path) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -88,8 +119,14 @@ const useScrollSpy = (ids = [], options = {}, enabled = true) => {
   return activeId;
 };
 
-const TabPanel = ({ tab, isActive, isSidebarOpen, closeSidebar }) => {
-  const { data, loading, error } = useJsonData(tab.dataPath);
+const TabPanel = ({ tab, isActive, isSidebarOpen, closeSidebar, language }) => {
+  const localizedText = textContent[language] ?? textContent.sv;
+  const dataPath = useMemo(() => {
+    if (typeof tab.dataPath === 'string') return tab.dataPath;
+    return tab.dataPath?.[language] || tab.dataPath?.sv || tab.dataPath?.fa || '';
+  }, [language, tab.dataPath]);
+
+  const { data, loading, error } = useJsonData(dataPath);
   const items = useMemo(() => (Array.isArray(data) ? data : []), [data]);
   const [selectedPdfId, setSelectedPdfId] = useState(null);
   const isPdfTab = tab.id === 'pdfs';
@@ -112,18 +149,39 @@ const TabPanel = ({ tab, isActive, isSidebarOpen, closeSidebar }) => {
   }, [isPdfTab, items]);
 
   const selectedPdf = isPdfTab ? items.find((item) => item.id === selectedPdfId) : null;
+  const direction = language === 'fa' ? 'rtl' : 'ltr';
+
+  const getLocalizedField = (item, field) => {
+    const baseValue = item[field];
+    if (baseValue && typeof baseValue === 'object' && !Array.isArray(baseValue)) {
+      return baseValue[language] || baseValue.sv || baseValue.fa || Object.values(baseValue)[0];
+    }
+
+    if (item.translations?.[language]?.[field]) {
+      return item.translations[language][field];
+    }
+
+    return baseValue;
+  };
+
+  const tabLabel = typeof tab.label === 'string' ? tab.label : tab.label[language] || tab.label.sv || tab.id;
 
   return (
-    <section id={tab.id} className={`tabcontent ${isActive ? 'active' : ''}`} aria-hidden={!isActive}>
+    <section
+      id={tab.id}
+      className={`tabcontent ${isActive ? 'active' : ''}`}
+      aria-hidden={!isActive}
+      dir={direction}
+    >
       <div className="tab-inner">
         <aside className={`sidebar ${isActive && isSidebarOpen ? 'open' : ''}`}>
-          {loading && <p>Loading list…</p>}
-          {error && <p role="alert">Failed to load content.</p>}
+          {loading && <p>{localizedText.loadingList}</p>}
+          {error && <p role="alert">{localizedText.loadError}</p>}
           {!loading && !error && (
             <nav>
               {items.map((item, index) => {
                 const itemId = item.id || `${tab.id}-${index}`;
-                const label = item.title || `Item ${index + 1}`;
+                const label = getLocalizedField(item, 'title') || `Item ${index + 1}`;
                 if (isPdfTab) {
                   return (
                     <button
@@ -151,40 +209,44 @@ const TabPanel = ({ tab, isActive, isSidebarOpen, closeSidebar }) => {
           )}
         </aside>
         <main className="content">
-          {loading && <p>Loading content…</p>}
-          {error && <p role="alert">Could not render {tab.label} just yet.</p>}
+          {loading && <p>{localizedText.loadingContent}</p>}
+          {error && <p role="alert">{localizedText.renderError(tabLabel)}</p>}
           {!loading && !error && (
             <>
               {isPdfTab ? (
-                <PdfViewer item={selectedPdf} />
+                <PdfViewer item={selectedPdf} language={language} strings={localizedText} />
               ) : (
                 items.map((item, index) => {
                   const itemId = itemIds[index];
                   const galleryImages = item.img || item.image;
+                  const title = getLocalizedField(item, 'title');
+                  const text = getLocalizedField(item, 'text');
                   return (
                     <article key={itemId} id={itemId} className="performance-item">
-                      <h2>{item.title || 'Untitled entry'}</h2>
-                      {item.text && (
-                        <div className="text-content" dangerouslySetInnerHTML={{ __html: item.text }} />
+                      <h2>{title || 'Untitled entry'}</h2>
+                      {text && (
+                        <div className="text-content" dangerouslySetInnerHTML={{ __html: text }} />
                       )}
 
-                      <ImageGallery images={galleryImages} title={item.title} />
+                      <ImageGallery images={galleryImages} title={title} language={language} strings={localizedText} />
                       <VideoPlayer
                         videoID={item.videoID}
                         video={item.video}
                         poster={item.poster}
-                        title={item.title}
+                        title={title}
+                        language={language}
+                        strings={localizedText}
                       />
 
                       {item.pdf && !isPdfTab && (
                         <p>
                           <a href={item.pdf} target="_blank" rel="noreferrer">
-                            Öppna PDF-dokument
+                            {localizedText.openPdf}
                           </a>
                         </p>
                       )}
 
-                      <SourceAttribution source={item.source} />
+                      <SourceAttribution source={item.source} language={language} strings={localizedText} />
                     </article>
                   );
                 })

--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -1,22 +1,30 @@
 import { useMemo } from 'react';
 import './VideoPlayer.css';
 
-const VideoPlayer = ({ videoID, video, poster, title }) => {
+const fallbackStrings = {
+  videoTitle: (itemTitle) => itemTitle || 'Video från YouTube',
+  videoFallback: 'Din webbläsare stödjer inte video-taggen.'
+};
+
+const VideoPlayer = ({ videoID, video, poster, title, language, strings }) => {
   const normalizedVideos = useMemo(() => {
     if (!video) return [];
     if (Array.isArray(video)) return video.filter(Boolean);
     return [video];
   }, [video]);
 
+  const copy = strings || fallbackStrings;
+  const direction = language === 'fa' ? 'rtl' : 'ltr';
+
   if (!videoID && !normalizedVideos.length) return null;
 
   return (
-    <div className="video-section">
+    <div className="video-section" dir={direction}>
       {videoID && (
         <div className="video-container">
           <iframe
             src={`https://www.youtube.com/embed/${videoID}`}
-            title={title || 'Video från YouTube'}
+            title={copy.videoTitle?.(title)}
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
           ></iframe>
@@ -26,7 +34,7 @@ const VideoPlayer = ({ videoID, video, poster, title }) => {
       {normalizedVideos.map((src) => (
         <video key={src} controls poster={poster || undefined} preload="metadata">
           <source src={src} />
-          Din webbläsare stödjer inte video-taggen.
+          {copy.videoFallback}
         </video>
       ))}
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;500;600;700&display=swap');
 
 *,
 *::before,
@@ -40,6 +41,10 @@ body {
   color: var(--color-primary-strong);
   line-height: 1.7;
   min-height: 100vh;
+}
+
+body[dir='rtl'] {
+  font-family: 'Vazirmatn', 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 body.sidebar-open {


### PR DESCRIPTION
## Summary
- add language toggle and persistence for Persian and Swedish, including RTL adjustments
- localize tab panels, media viewers, and supporting text with bilingual copy
- update styling and lint configuration to support the new language experience

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e52d37f988328af1a9315d57025ba)