### PR TITLE
Add Persian content and adjust language switch alignment

### DIFF
--- a/public/data/Performance.fa.json
+++ b/public/data/Performance.fa.json
@@ -1,0 +1,224 @@
+[
+  {
+    "id": "ShahrdadRohani",
+    "title": "کنسرت با استاد شهرداد روحانی در استکهلم (۱۷ مه ۲۰۲۵)",
+    "img": null,
+    "videoID": "90EFCKvdDNY",
+    "text": "من و دخترم کیمیا در کنسرتی به رهبری شهرداد روحانی قطعه‌ای را برای وطن و آزادی اجرا کردیم؛ اجرایی که نمادی از آزادی هنری و ایستادگی در برابر سانسور و فشارهای ایران بود.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=90EFCKvdDNY"
+    }
+  },
+  {
+    "id": "Parvaz-E_Khiyal",
+    "title": "پرواض خیال (۱۱ مه ۲۰۲۵)",
+    "videoID": "Gxp9wjiAZFE",
+    "text": "کنسرتی با محور تنبور و روایت‌های یارسان؛ قطعه اصلی مقام طرز بود و پیام آن آزادی آواز و حمایت از حقوق زنان در هنر. به دلیل ممنوعیت موسیقی یارسان در ایران، این اجرا سندی از خطرات بازگشت ما به ایران است.",
+    "source": {
+      "label": "APARAT",
+      "url": "https://www.youtube.com/watch?v=Gxp9wjiAZFE"
+    }
+  },
+  {
+    "id": "GudsSjuNamn",
+    "title": "هفت نام خدا (۷ فوریه ۲۰۲۵)",
+    "img": [
+      "./assets/picture/GudsSjuNamn.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "آهنگی بر اساس شعر مهر بابا با تنبور من و آواز فریماهر که در اینستاگرام بیش از ۷۰ هزار بازدید گرفت. اجرای چنین کاری در ایران به علت ممنوعیت آواز زنان و پیام آزادی بیان ممکن نبود.",
+    "source": {
+      "label": "www.instagram.com",
+      "url": "https://www.instagram.com/reel/DFxuuL9uroi/?igsh=ZGpjemFscDZlY3Nr"
+    }
+  },
+  {
+    "id": "NimaSarvestani",
+    "title": "اجرای خصوصی نزد نیما سروستانی (۲۲ دسامبر ۲۰۲۴)",
+    "img": null,
+    "videoID": "d0pFnWyig10",
+    "text": "به دعوت نیما سروستانی، مستندساز منتقد رژیم ایران، به همراه دخترم قطعاتی با موضوع آزادی و عدالت اجرا کردیم. حضور ما در جمعی ضد رژیم می‌تواند در ایران خطر دستگیری و بازجویی به همراه داشته باشد.",
+    "source": {
+      "label": "Nashr Baran",
+      "url": "https://www.instagram.com/reel/DD2z9zgNEfe/?igsh=MXRjYnFlaW5vZnR6bA=="
+    }
+  },
+  {
+    "id": "eurokurd2024",
+    "title": "یوروکرد ۲۰۲۴",
+    "img": null,
+    "poster": "./assets/picture/eurokurd2024.jpg",
+    "videoID": "q999bCIQ_3E",
+    "text": "همکاری گروه بالوشان با یارسان در یک برنامه مشترک.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=q999bCIQ_3E"
+    }
+  },
+  {
+    "id": "KurdiskaKulturFestivalen2024",
+    "title": "جشنواره فرهنگ کردی ۲۰۲۴",
+    "img": [
+      "./assets/picture/Exilkonserter2024_1.jpg"
+    ],
+    "video": "./assets/video/KurdiskaKulturFestivalen2024.mp4",
+    "poster": "./assets/video/KurdiskaKulturFestivalen2024.jpg",
+    "text": "کنسرت تبعیدیان با گروه یاران در حمایت از آزادی زنان و اعتراض به ممنوعیت صدای زنان در ایران.",
+    "source": null
+  },
+  {
+    "id": "huddinge2023",
+    "title": "جشنواره هودینگه ۲۰۲۳",
+    "img": null,
+    "videoID": "",
+    "text": "اجرای گروه یاران در فستیوال فولکلور هودینگه به دعوت برگزارکنندگان برای حمایت از موسیقی ایرانی، یارسان و جامعه مهاجر.",
+    "source": {
+      "label": "INSTAGRAM",
+      "url": "https://www.instagram.com/p/CtlQ9f7oSYD/?img_index=1&igsh=MXJycWp5aGpwNzZvOA%3D%3D"
+    }
+  },
+  {
+    "id": "minneAvJina_4",
+    "title": "یاد ژینا – هلسینکی (۲۲ آوریل ۲۰۲۳)",
+    "img": [
+      "./assets/picture/minneAvJina_4.jpg"
+    ],
+    "text": "یکی از ویدئوهای من با بیش از ۹۶ هزار بازدید و محتوای انتقادی نسبت به رژیم و دفاع از آزادی زنان؛ نشان‌دهنده دیده شدن فعالیت‌ها و خطر بازگشت به ایران.",
+    "source": {
+      "label": "Instagram",
+      "url": "https://www.instagram.com/reel/DGAXMiwu2Sw/?igsh=YnM5Z3JpZW13ZXc3"
+    }
+  },
+  {
+    "id": "shokobanHelsingfors2023",
+    "title": "شکوبان – هلسینکی ۲۰۲۳",
+    "img": [
+      "./assets/picture/shokobanHelsingfors2023.jpg"
+    ],
+    "videoID": "dys18vpptYE",
+    "text": "کنسرتی در فنلاند به یاد شهیدان جنبش زن، زندگی، آزادی، برگزارشده با وجود تهدیدهای رژیم ایران.",
+    "source": {
+      "label": "www.youtube.com",
+      "url": "https://www.youtube.com/watch?v=dys18vpptYE"
+    }
+  },
+  {
+    "id": "shokobanOslo2023",
+    "title": "شکوبان – اسلو ۲۰۲۳",
+    "videoID": "PCevAW-VT8U",
+    "poster": null,
+    "text": "به عنوان رهبر و آهنگساز، کنسرت‌هایی در نروژ در حمایت از جنبش زن، زندگی، آزادی و اعتراض به سرکوب هنرمندان برگزار کردم.",
+    "source": {
+      "label": "www.youtube.com",
+      "url": "https://www.youtube.com/watch?v=PCevAW-VT8U"
+    }
+  },
+  {
+    "id": "minneAvJina_1",
+    "title": "یاد ژینا – اجراهای اروپایی (۸ آوریل ۲۰۲۳)",
+    "img": null,
+    "videoID": "pMnoTgFbVrA",
+    "text": "قطعه‌ای یادبود برای ژینا همراه گروه موسیقی در شهرهای مختلف اروپا اجرا شد و پیام آزادی و اعتراض را به هزاران مخاطب منتقل کرد؛ اشعار آن درباره مقاومت و امید است.",
+    "source": {
+      "label": "youtube",
+      "url": "https://www.youtube.com/watch?v=pMnoTgFbVrA"
+    }
+  },
+  {
+    "id": "minneAvJina_2",
+    "title": "یاد ژینا – استکهلم ۲ (۸ آوریل ۲۰۲۳)",
+    "img": null,
+    "videoID": null,
+    "poster": "./assets/video/minneAvJina_2.jpg",
+    "video": "./assets/video/minneAvJina_2.mp4",
+    "text": "اجرایی بر اساس شعر کهن شاه خوشین با بازخوانی وضعیت امروز ایران؛ بیانگر خیزش مردم، تبعیض دینی و امید به آزادی که در تور اروپایی اجرا شد.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?si=Sy3X3hQVJRQMma3K&v=6QtDSED0WiU&feature=youtu.be"
+    }
+  },
+  {
+    "id": "minneAvJina_3",
+    "title": "یاد ژینا – استکهلم ۳ (۸ آوریل ۲۰۲۳)",
+    "img": null,
+    "videoID": "RoOkCYRqQP4",
+    "text": "بازآفرینی شعر شاه خوشین در تور اروپا برای بازگویی ظلم، تبعیض دینی و امید به رهایی؛ به‌عنوان اعتراض هنری و معنوی علیه دیکتاتوری.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=RoOkCYRqQP4"
+    }
+  },
+  {
+    "id": "Frankfurt2023",
+    "title": "کنسرت فرانکفورت (۲۳ مارس ۲۰۲۳)",
+    "img": null,
+    "videoID": "wOzmVtZcNL_Uvqd1",
+    "video": null,
+    "text": "کنسرتی با بیش از ۵۰۰۰ نفر به یاد ژینا و در حمایت از برابری و حقوق دختران ایرانی؛ بخشی از جنبش زن، زندگی، آزادی که از طریق آریان‌تی‌وی پخش شد.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://youtu.be/0ZxbQLRSiIM?si=wOzmVtZcNL_Uvqd1"
+    }
+  },
+  {
+    "id": "goteborg2022",
+    "title": "فستیوال موسیقی جهان – گوتنبرگ ۲۰۲۲",
+    "img": [
+      "./assets/picture/göteborg_2022.jpg"
+    ],
+    "video": [
+      "./assets/video/goteborg_2022_1.mp4",
+      "./assets/video/goteborg_2022_2.mp4"
+    ],
+    "poster": null,
+    "text": "اجرای آنلاین از ایران با حضور نووا پیری در شرایط پنهانی؛ تلاشی برای حمایت از صدای زنان و آزادی بیان هنری با وجود تهدیدهای رژیم.",
+    "source": {
+      "label": "INSTAGRAM",
+      "url": "https://www.instagram.com/p/CNIAGtSnrWd/?igsh=dmFkMGcwMzFlN3Bp"
+    }
+  },
+  {
+    "id": "goteborg2016",
+    "title": "گرامیداشت سید خلیل عالی‌نژاد – گوتنبرگ ۲۰۱۶",
+    "videoID": "zYY-ICwvKHA",
+    "text": "مراسم بزرگداشت با خوانندگی ملیحه مرادی و رهبری من برای پاسداشت موسیقی یارسان و آزادی هنری زنان.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=zYY-ICwvKHA"
+    }
+  },
+  {
+    "id": "Newroz_2016",
+    "title": "دعوت به نوروز تی‌وی – سپتامبر ۲۰۱۶",
+    "videoID": "4RBSQfi56lg",
+    "text": "اجرای موسیقی و گفت‌وگو درباره مشکلات یارسان و معرفی فرهنگ یارسان در ایران؛ ادامه مبارزه هنری من با وجود ممنوعیت‌ها.",
+    "source": {
+      "label": "YouTube",
+      "url": "https://www.youtube.com/watch?v=4RBSQfi56lg"
+    }
+  },
+  {
+    "id": "Avslutningen på konserten 2016",
+    "title": "پایان کنسرت ۲۰۱۶",
+    "img": null,
+    "videoID": "ir6ihjymRQ4",
+    "text": "در پایان کنسرت استکهلم ۲۰۱۶ توسط علیرضا مجلل و زینت پیرزاده به عنوان کنشگر فعال حقوق زنان معرفی شدم؛ حضور خواننده زن (ملیحه مرادی) نماد اعتراض به محدودیت‌ها بود.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=ir6ihjymRQ4&ab_channel=KeyvanKianian"
+    }
+  },
+  {
+    "id": "KonservatorietIGent",
+    "title": "کارگاه کنسرواتوار گِنت – ۲۰۱۳",
+    "img": null,
+    "videoID": "6lwK3qb5SJk",
+    "text": "دعوت رسمی کنسرواتوار گنت بلژیک برای تدریس سازسازی و موسیقی ایرانی به دانشجویان اروپایی؛ نمونه‌ای از فعالیت بین‌المللی و جایگاهم در موسیقی سنتی ایران.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=6lwK3qb5SJk"
+    }
+  }
+]

--- a/public/data/artiklar.fa.json
+++ b/public/data/artiklar.fa.json
@@ -1,0 +1,252 @@
+[
+  {
+    "id": "cgie",
+    "title": "مقاله دانشنامه اسلامی (۲۰۱9)",
+    "img": [
+      "./assets/picture/cgie_2017.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "مقاله «جایگاه موسیقی مقام در موسیقی نواحی» درباره موسیقی یارسان و پژوهش‌های من در ۱۳ ژانویه ۲۰۱۹ منتشر شد و نشان‌دهنده تلاش برای حفظ این میراث در برابر محدودیت‌های ایران است.",
+    "source": {
+      "label": "CGIE.ORG.IR",
+      "url": "https://www.cgie.org.ir/fa/news/177525/%D8%AC%D8%A7%DB%8C%DA%AF%D8%A7%D9%87-%D9%85%D9%82%D8%A7%D9%85-%D8%AF%D8%B1-%D9%85%D9%88%D8%B3%DB%8C%D9%82%DB%8C-%D9%86%D9%88%D8%A7%D8%AD%DB%8C---%DA%A9%DB%8C%D9%88%D8%A7%D9%86-%DA%A9%DB%8C%D8%A7%D9%86%DB%8C%D8%A7%D9%86"
+    }
+  },
+  {
+    "id": "honardastan",
+    "title": "هنرستان – ۲۰۱۷",
+    "img": [
+      "./assets/picture/honardastan_2017.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "گزارش و گفت‌وگو درباره نابرابری علیه موسیقی مقام، تنبور و سنت یارسان؛ توضیح داده‌ام چگونه با وجود خطرات، برای زنده ماندن این هنر در ایران مبارزه کرده‌ام.",
+    "source": {
+      "label": "HONARDASTAN.IR",
+      "url": "https://honardastan.ir/4203/%D8%AF%D8%B1-%D8%AD%D9%82-%D9%85%D9%88%D8%B3%DB%8C%D9%82%DB%8C-%D9%85%D9%82%D8%A7%D9%85%DB%8C-%D8%B8%D9%84%D9%85-%D8%B4%D8%AF%D9%87-%D8%A7%D8%B3%D8%AA/"
+    }
+  },
+  {
+    "id": "radiohamrah",
+    "title": "رادیو همراه ۲۰۱۷",
+    "img": [
+      "./assets/picture/RadioHamrah_i_Los_Angeles_2017.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "گفت‌وگو در لس‌آنجلس درباره تنبور، موسیقی مقام و میراث معنوی یارسان.",
+    "source": null
+  },
+  {
+    "id": "Isna",
+    "title": "خبرگزاری ایسنا ۲۰۱۷",
+    "img": [
+      "./assets/picture/ISNA_Picture.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "مصاحبه ۱۶ مه ۲۰۱۷ درباره بی‌عدالتی در قبال موسیقی سنتی یارسان.",
+    "source": {
+      "label": "ISNA",
+      "url": "https://www.isna.ir/amp/96022516476/"
+    }
+  },
+  {
+    "id": "yarsan2016",
+    "title": "فدراسیون یارسان – ۲۰۱۶",
+    "img": [
+      "./assets/picture/Yarsanfederationens_styrelse_2016.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "نشست استکهلم با هیئت فدراسیون یارسان و هنرمندان ایران و سوئد برای هماهنگی کنسرتی در حمایت از فرهنگ یارسان و مقابله با محدودیت‌های ایران.",
+    "source": {
+      "label": "YARSANF",
+      "url": "https://www.yarsanf.org/index/2016/08/25/%D8%AF%DB%8C%D8%AF%D8%A7%D8%B1-%DB%8C%DA%A9-%D8%AA%DB%8C%D9%85-%D8%AF%D9%88-%D9%86%D9%81%D8%B1%D9%87-%D8%A7%D8%B2-%D9%87%DB%8C%D8%A6%D8%AA-%D9%85%D8%AF%DB%8C%D8%B1%D9%87-%D9%81%D8%AF%D8%B1%D8%A7/"
+    }
+  },
+  {
+    "id": "radio2011",
+    "title": "رادیو سوئد ۲۰۱۱",
+    "img": [
+      "./assets/picture/radioSverige_2011.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "کنسرت گروه بالوشان به رهبری من در شهرهای سوئد با حضور نوازندگان و خوانندگان زن در ۲۸ ژانویه ۲۰۱۱.",
+    "source": {
+      "label": "RADIO SVERIGE",
+      "url": "https://www.sverigesradio.se/artikel/4317735"
+    }
+  },
+  {
+    "id": "farhang2010",
+    "title": "همکاری با انجمن فرهنگ – ۲۰۱۰",
+    "img": [
+      "./assets/picture/farhang_2010.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "کنسرت ۴ مارس ۲۰۱۰ با حمایت انجمن فرهنگ و فدراسیون یارسان برای معرفی موسیقی و فرهنگ یارسان در سوئد.",
+    "source": {
+      "label": "www.farhang.nu",
+      "url": "https://www.farhang.nu/balvashan-ensemble-i-samarbete-med-yarsan-forbundet/"
+    }
+  },
+  {
+    "id": "gisso2019",
+    "title": "کنسرت تاریخی شکوبان – استکهلم",
+    "img": [
+      "./assets/picture/uppsala_2019.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "اجرای شکوبان در اریک اریکسون‌هالن به عنوان بخشی از تور اروپا با شعار «زن، زندگی، آزادی»؛ اعتراضی هنری برای آزادی زنان با وجود خطرات شخصی.",
+    "source": null
+  },
+  {
+    "id": "goteborg2019",
+    "title": "فستیوال بین‌المللی گوتنبرگ ۲۰۱۹",
+    "img": [
+      "./assets/picture/göteborg_2019.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "دعوت به عنوان هنرمند ایرانی برای اجرای موسیقی ملی و آثار یارسان؛ تلاشی برای حفظ هویت معنوی و آزادی هنری در برابر محدودیت‌های ایران.",
+    "source": {
+      "label": "INSTAGRAM",
+      "url": "https://www.instagram.com/p/Bvrw5CIgnz0/?igsh=MXViY2FyMW44ZWNleg%3D%3D"
+    }
+  },
+  {
+    "id": "balvashan2016",
+    "title": "کنسرت بالوشان – اوپسالا ۲۰۱۶",
+    "img": [
+      "./assets/picture/uppsala_2016.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "اجرای موسیقی سنتی فارسی و کردی با خوانندگی ملیحه مرادی؛ حضور خواننده زن به‌عنوان حمایت از آزادی صدای زنان با وجود ممنوعیت در ایران.",
+    "source": null
+  },
+  {
+    "id": "sverigesRadio2023",
+    "title": "مصاحبه رادیو سوئد – ۲۰۲۳",
+    "img": [
+      "./assets/picture/SR_2023_1.jpg",
+      "./assets/picture/SR_2023_2.jpg"
+    ],
+    "text": "گفتگو درباره اجرای شکوبان به یاد ژینا و جنبش زن، زندگی، آزادی در تور اروپا؛ تاریخ مصاحبه ۶ آوریل ۲۰۲۳.",
+    "source": {
+      "label": "www.sverigesradio.se",
+      "url": "https://www.sverigesradio.se/artikel/%D9%87%D9%88%D9%86%DB%95%D8%B1%D9%85%DB%95%D9%86%D8%AF-%D8%AD%D9%88%D8%B3%DB%8E%D9%86-%D8%B3%DB%95%D9%81%D8%A7%D9%85%DB%95%D9%86%D8%B4-%D8%A8%DB%86-%DB%8C%DB%95%DA%A9%DB%95%D9%85%D8%AC%D8%A7%D8%B1-%D9%84%DB%95-%D8%B3%D9%88%DB%8C%D8%AF-%DA%A9%DB%86%D9%86%D8%B3%DB%8E%D8%B1%D8%AA-%D8%AF%DB%95%DA%AF%DB%8E%D8%B1%DB%8E%D8%AA"
+    }
+  },
+  {
+    "id": "worldMusicFestival2023",
+    "title": "جینا (مهسا) – گوتنبرگ، آوریل ۲۰۲۳",
+    "img": [
+      "./assets/picture/worldMusicFestival2023.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "کنسرت ۱ و ۲ آوریل ۲۰۲۳ به یاد مهسا امینی و حمایت از جنبش زن، زندگی، آزادی با رهبری من؛ رساندن صدای زنان ایرانی به صحنه بین‌المللی.",
+    "source": {
+      "label": "www.instagram.com",
+      "url": "https://www.instagram.com/p/CqMJZjlKXP9/?igsh=bGhjaDI4YWU0MWpo"
+    }
+  },
+  {
+    "id": "shokobanBryssel2023",
+    "title": "شکوبان – بروکسل ۲۰۲۳",
+    "img": [
+      "./assets/picture/shokobanBryssel2023.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "کنسرت ۱۸ مارس ۲۰۲۳ به یاد شهیدان جنبش زن، زندگی، آزادی؛ اجرا با وجود تهدیدهای رژیم ایران.",
+    "source": null
+  },
+  {
+    "id": "shokobanRotterdam2023",
+    "title": "شکوبان – روتردام ۲۰۲۳",
+    "img": [
+      "./assets/picture/shokobanRotterdam2023.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "کنسرت ۱۷ مارس ۲۰۲۳ در حمایت از انقلاب زن، زندگی، آزادی و در یادبود شهدا، علی‌رغم تهدیدهای رژیم.",
+    "source": null
+  },
+  {
+    "id": "HonarOnline1",
+    "title": "بازتاب در رسانه‌های ایران (HonarOnline)",
+    "img": [
+      "./assets/picture/HonarOnline1.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "مقاله «گروه بالوشان با دو آلبوم جدید می‌آید» نام و فعالیت‌های مرا ذکر کرده و نشان می‌دهد در ایران شناخته‌شده‌ام.",
+    "source": {
+      "label": "/www.honaronline.ir",
+      "url": "https://www.honaronline.ir/%D8%A8%D8%AE%D8%B4-%D8%A7%D8%AE%D8%A8%D8%A7%D8%B1-5/19184-%DA%AF%D8%B1%D9%88%D9%87-%D8%A8%D8%A7%D9%84-%D9%88%D8%B4%D8%A7%D9%86-%D8%A8%D8%A7-%D8%AF%D9%88-%D8%A2%D9%84%D8%A8%D9%88%D9%85-%D8%AC%D8%AF%DB%8C%D8%AF-%D9%85%DB%8C-%D8%A2%DB%8C%D8%AF"
+    }
+  },
+  {
+    "id": "draVadiEshgh",
+    "title": "آلبوم «دره وادی عشق»",
+    "img": [
+      "./assets/picture/dra-vadi-eshgh.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "انتشار آثارم در پلتفرم نواک (مشابه اسپاتیفای در ایران) گواه توزیع رسمی و شناخته‌شدن من است.",
+    "source": {
+      "label": "/www.navaak.com",
+      "url": "https://navaak.com/album/salar-aghili-keyvan-kianian-dra-vadi-eshgh"
+    }
+  },
+  {
+    "id": "penhanak1",
+    "title": "آلبوم «پنهانک» در بیپ‌تونز",
+    "img": [
+      "./assets/picture/penhanak.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "انتشار آلبوم در بزرگ‌ترین سرویس قانونی موسیقی ایران نشان‌دهنده پذیرش رسمی آثارم است.",
+    "source": {
+      "label": "/www.beeptunes.com",
+      "url": "https://beeptunes.com/album/3410283/%D9%BE%D9%86%D9%87%D8%A7%D9%86%DA%A9"
+    }
+  },
+  {
+    "id": "Penhanak2",
+    "title": "موفقیت فروش پنهانک (جام‌جم آنلاین)",
+    "img": [
+      "./assets/picture/penhanak2.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "گزارش رسانه سراسری جام‌جم از چاپ مجدد آلبوم پنهانک پس از فروش بالا و تأیید موفقیت آن.",
+    "source": {
+      "label": "https://jamejamonline.ir",
+      "url": "https://jamejamonline.ir/fa/news/868094/%D9%BE%D9%86%D9%87%D8%A7%D9%86%DA%A9-%D8%A8%D8%A7%D8%B1-%D8%AF%DB%8C%DA%AF%D8%B1-%D8%AF%D8%B1-%D8%A8%D8%A7%D8%B2%D8%A7%D8%B1-%D9%85%D9%88%D8%B3%DB%8C%D9%82%DB%8C"
+    }
+  },
+  {
+    "id": "serre-hezar-sale",
+    "title": "آلبوم «سر هزار سال»",
+    "img": [
+      "./assets/picture/serre-hezar-sale.jpg"
+    ],
+    "video": null,
+    "poster": null,
+    "text": "انتشار این آلبوم در نواک نشان می‌دهد که آثارم به‌طور رسمی در ایران پخش و شناخته می‌شوند.",
+    "source": {
+      "label": "/www.navaak.com",
+      "url": "https://navaak.com/album/salar-aghili-serre-hezar-sale"
+    }
+  }
+]

--- a/public/data/bilder.fa.json
+++ b/public/data/bilder.fa.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "stockholm",
+    "title": "فعالیت سیاسی در استکهلم",
+    "img": [
+      "./assets/picture/amineKakaBaveh.jpg",
+      "./assets/picture/ashkan_mojalal_stockholm.jpg",
+      "./assets/picture/najm_eldin_gholami.jpg",
+      "./assets/picture/naser_razazi_stockholm.jpg",
+      "./assets/picture/showanParvar_stockholm.jpg",
+      "./assets/picture/keyhanKalhor&RostaMirLaShari.jpg"
+    ],
+    "text": "<p>به عنوان بخشی از تلاش مداومم برای آزادی بیان در ایران، در استکهلم با چهره‌های شناخته‌شده سیاسی و فرهنگی دیدار می‌کنم و پیوسته در گفتگو و تبادل نظر با آنها هستم.</p><p><strong>آمنه کاکاباوه</strong> – فعال حقوق بشر و نماینده پیشین پارلمان سوئد.</p><p><strong>اشکان خطیبی</strong> – زندانی سیاسی سابق در ایران و فعال سیاسی در تبعید.</p><p><strong>علیرضا مجلل</strong> – بازیگر و کارگردان ساکن سوئد و درگیر فعالیت‌های سیاسی.</p><p><strong>شوان پارور</strong> – خواننده و هنرمند سیاسی.</p><p><strong>ناصر رضا‌زی</strong> – فعال سیاسی.</p><p><strong>کیهان کلهر و رستم میرلاشاری</strong> – هنرمندان و فعالان سیاسی.</p>",
+    "source": null
+  },
+  {
+    "id": "sabuni2013",
+    "title": "کنفرانس حقوق زنان در استکهلم – ۲۰۱۳",
+    "img": [
+      "./assets/picture/Nyamko_with_me.jpg",
+      "./assets/picture/Nyamko_with_me_2.jpg",
+      "./assets/picture/Nyamko_with_me_3.jpg"
+    ],
+    "text": "حضور در کنفرانس حقوق زنان در سال ۲۰۱۳؛ در این برنامه درباره مشکلات دختران ایرانی سخنرانی کردم، اجرا داشتم و با نیامکو سابونی (وزیر پیشین برابری سوئد) درباره وضعیت زنان ایران گفتگو کردم.",
+    "source": null
+  },
+  {
+    "id": "yarsansstod",
+    "title": "حمایت یارسان",
+    "img": [
+      "./assets/picture/Nasrudin_heydari.jpg",
+      "./assets/picture/najm_aldin_heydari.jpg",
+      "./assets/picture/yaresan_kändis.jpg"
+    ],
+    "text": "<p>سید نصرالدین حیدری و جانشین او سید نجم‌الدین حیدری حمایت خود را از فعالیت هنری من برای حفظ موسیقی و فرهنگ یارسان اعلام کرده‌اند. نقش من به عنوان نوازنده تنبور و پاسدار این میراث تأیید شده و در راستای احیای هویت یارسان ادامه دارد.</p><p>در عکس دیگر در کنار نئامت زحمتکش، ایرج زحمتکش و کیوان قلخانی دیده می‌شوم که بیانگر ارتباط نزدیکم با جامعه یارسان است.</p>",
+    "source": null
+  },
+  {
+    "id": "oslo",
+    "title": "فعالیت سیاسی در اسلو",
+    "img": [
+      "./assets/picture/azad_azizi_oslo.jpg",
+      "./assets/picture/eliasi_oslo.jpg",
+      "./assets/picture/kaveh_oslo.jpg"
+    ],
+    "text": "دیدار با چند فعال سیاسی سرشناس از جمله آزاد عزیزی و استاد قادر الیاسی در اسلو.",
+    "source": null
+  },
+  {
+    "id": "minaAktiviteter",
+    "title": "پوسترهای فعالیت‌های هنری من",
+    "img": [
+      "./assets/picture/sangMotTystnaden2025.jpg",
+      "./assets/picture/minaAktiviteter_1.jpg",
+      "./assets/picture/minaAktiviteter_2.jpg",
+      "./assets/picture/minaAktiviteter_3.jpg",
+      "./assets/picture/minaAktiviteter_4.jpg",
+      "./assets/picture/minaAktiviteter_5.jpg",
+      "./assets/picture/minaAktiviteter_6.jpg",
+      "./assets/picture/minaAktiviteter_7.jpg",
+      "./assets/picture/yaranBand2024.jpg",
+      "./assets/picture/worldMusicFestival2023.jpg",
+      "./assets/picture/shokobanOslo2023.jpg"
+    ],
+    "text": "این پوسترها بخشی از برنامه‌های موسیقایی و فرهنگی من در شهرهای مختلف سوئد است که برای حمایت از حقوق زنان و آزادی بیان هنری برگزار شده‌اند. به عنوان رهبر و آهنگساز گروه \"یاران\" به فعالیت برای آزادی هنری زنان در سوئد و جهان ادامه می‌دهم.",
+    "source": null
+  },
+  {
+    "id": "khavankar",
+    "title": "جشن خواونکار در تلویزیون آریان",
+    "img": [
+      "./assets/picture/khavankar.jpg"
+    ],
+    "text": "<p>پس از مراسم مذهبی، جشن <strong>خواونکار (یارسان)</strong> را همراه خانواده و هنرجویان موسیقی با اجرای زنده در تلویزیون آریان برگزار کردیم.</p><p>برنامه شامل موسیقی و آیین‌های سنتی یارسان بود و میراث معنوی این فرهنگ را نشان داد.</p>",
+    "source": null
+  },
+  {
+    "id": "NimaSarvestani",
+    "title": "در کنار چهره‌های فرهنگی ایرانی در سوئد",
+    "img": [
+      "./assets/picture/NimaSarvestani.jpg"
+    ],
+    "text": "<p>در این عکس همراه چند چهره برجسته جامعه فرهنگی ایرانی–سوئدی دیده می‌شوم:</p><ul><li><strong>نیما سروستانی</strong> – مستندساز برنده جایزه و مدافع حقوق بشر.</li><li><strong>آمنه کاکاباوه</strong> – نماینده پیشین پارلمان و فعال حقوق زنان و منتقد رژیم ایران.</li><li><strong>مسعود مافعان</strong> – مسئول انتشارات باران در استکهلم.</li><li><strong>هلن همتی همارستروم</strong> – کارگردان و نمایشنامه‌نویس ایرانی–سوئدی.</li><li><strong>کیمیا</strong> – دخترم.</li></ul><p>این حضور نشان‌دهنده ارتباط نزدیک من با جامعه هنری مخالف رژیم ایران است.</p>",
+    "source": null
+  }
+]

--- a/public/data/interview.fa.json
+++ b/public/data/interview.fa.json
@@ -1,0 +1,148 @@
+[
+  {
+    "id": "ArianTv_2025_10_10",
+    "title": "جمع‌بندی مصاحبه آریان‌تی‌وی (۱۰ اکتبر ۲۰۲۵)",
+    "img": null,
+    "poster": "./assets/picture/ariantv_20251010.jpg",
+    "videoID": "neFYA6MJa5A",
+    "text": "در این گفتگو درباره هنر اعتراضی صحبت کردم؛ وقتی آزادی بیان ممنوع است، شعر و موسیقی به ابزار مقاومت مردم تبدیل می‌شود و آثار من نیز از همین واقعیت زاده شده‌اند.",
+    "source": {
+      "label": "www.youtube.com",
+      "url": "https://www.youtube.com/watch?v=neFYA6MJa5A"
+    }
+  },
+  {
+    "id": "eurokurd_2025-09-20",
+    "title": "مصاحبه یوروکورد (۲۰ سپتامبر ۲۰۲۵)",
+    "img": null,
+    "poster": "./assets/picture/eurokurd2025.jpg",
+    "videoID": "7jRPrZ9j8T4",
+    "text": "توضیح دادم که حکومت ایران دین یارسان را به رسمیت نمی‌شناسد و به همین دلیل در تحصیل و کار بارها محروم شده‌ام. در سوئد آزادانه باور خود را زندگی می‌کنیم؛ در ایران همین آزادی جرم محسوب می‌شود.",
+    "source": {
+      "label": "www.youtube.com",
+      "url": "https://www.youtube.com/watch?v=7jRPrZ9j8T4"
+    }
+  },
+  {
+    "id": "sverigesradio",
+    "title": "رادیو سوئد فارسی/دری (۱۵ مه ۲۰۲۵)",
+    "img": null,
+    "videoID": "jxywNpf0ME8",
+    "text": "خلاصه مصاحبه برای اداره مهاجرت: فعالیت‌های هنری من اعتراض به وضعیت سیاسی و اجتماعی ایران است و به خاطر باور یارسانی با تهدید روبه‌رو هستیم؛ بازگشت برای خانواده‌ام خطرناک است.",
+    "source": {
+      "label": "Radio Sweden",
+      "url": "https://fb.watch/zBzpyyykf-/"
+    }
+  },
+  {
+    "id": "IranInternational",
+    "title": "گزارش ایران اینترنشنال – کنسرت روز زن (۸ مارس ۲۰۲۵)",
+    "img": null,
+    "videoID": "lZhZG3zvukQ",
+    "text": "در این کنسرت خانوادگی درباره خطرات خوانندگی زنان و سرکوب هنرمندان صحبت کردیم؛ موسیقی ما بیانیه‌ای علیه سکوت اجباری و دفاع از فرهنگ یارسان بود.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=lZhZG3zvukQ"
+    }
+  },
+  {
+    "id": "Ikkr",
+    "title": "اجرای IKKR برای حقوق زنان (۷ مارس ۲۰۲۵)",
+    "img": null,
+    "videoID": "o0Zb1luN_64",
+    "text": "همراه خانواده و گروه یاران در هتل الیت وستروس برای آزادی زنان و حقوق یارسان اجرا داشتیم؛ چنین برنامه‌ای در ایران به دلیل پیام‌های آزادی‌خواهانه ممنوع است.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=o0Zb1luN_64"
+    }
+  },
+  {
+    "id": "arian-music-2024",
+    "title": "برنامه موسیقی آریان‌تی‌وی (۱۶ نوامبر ۲۰۲۴)",
+    "videoID": "55ECnkwBw4w",
+    "text": "اجرای ویژه جشن خواونکار با هنرجویان زن که در ایران اجازه خواندن ندارند؛ موسیقی را سلاحی برای حفظ هویت یارسان و آزادی زنان معرفی کردم.",
+    "source": {
+      "label": "YouTube",
+      "url": "https://www.youtube.com/watch?v=55ECnkwBw4w"
+    }
+  },
+  {
+    "id": "Yarsankulturinstitutet",
+    "title": "مصاحبه درباره بنیاد فرهنگ یارسان در تبعید (۲ دسامبر ۲۰۲۳)",
+    "img": null,
+    "videoID": "OfSp7ZA-Dws",
+    "text": "به دعوت طیب طاهری درباره تبعیض دینی در ایران، ضرورت آموزش آزاد موسیقی و ادبیات یارسان در تبعید و خطرات همکاری با این نهاد صحبت کردم.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=OfSp7ZA-Dws"
+    }
+  },
+  {
+    "id": "khavankar-firandet",
+    "title": "مستند جشن خواونکار – ۲۰۲۴",
+    "img": null,
+    "videoID": "eqDnsexTX7w",
+    "poster": "./assets/picture/khavankar-firandet.jpg",
+    "text": "ویدئوی جشن خواونکار در سوئد با اجرای گروه یارسان؛ درباره آموزش نسل جوان در تبعید و حفظ سنت‌هایی که در ایران سرکوب می‌شود سخن گفتم.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=eqDnsexTX7w"
+    }
+  },
+  {
+    "id": "RAZAN_2023",
+    "title": "برنامه «رازان» – ۲۰۲۲/۲۰۲۳",
+    "img": null,
+    "videoID": "58fX7pAXsEc",
+    "text": "مصاحبه‌ای که در تهران ضبط شد و پس از مهاجرت پخش شد؛ توضیح فعالیت‌های پنهانی برای حمایت از خوانندگان زن و خطراتی که به همین دلیل متحمل شدیم.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=58fX7pAXsEc"
+    }
+  },
+  {
+    "id": "AryanTV",
+    "title": "خلاصه مصاحبه آریان‌تی‌وی (۱۵ ژوئن ۲۰۲۳)",
+    "img": null,
+    "videoID": "chDyzQTS_ag",
+    "text": "ریشه و قدمت هزارساله موسیقی یارسان، تور اروپایی گروه من، و نقش هنرمندان در جنبش «زن، زندگی، آزادی» را توضیح دادم و بر اهمیت هنر در جامعه تأکید کردم.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=chDyzQTS_ag"
+    }
+  },
+  {
+    "id": "JinJiyanAzadi",
+    "title": "کنفرانس «زن، زندگی، آزادی» (۱۴ مه ۲۰۲۳)",
+    "img": null,
+    "videoID": "aG9tQ2QHKfk",
+    "poster": "./assets/picture/JinJiyanAzadi.jpg",
+    "text": "انتقاد کردم که هنرمندان کمتر به نشست‌های اعتراضی دعوت می‌شوند و پیشنهاد دادم آموزش هنر از کودکی برای مقابله با بی‌عدالتی جدی گرفته شود؛ حضورم در این برنامه به‌وضوح ضد رژیم است.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://www.youtube.com/watch?v=aG9tQ2QHKfk"
+    }
+  },
+  {
+    "id": "AryanTv_interview",
+    "title": "گفت‌وگو درباره سانسور در ایران (۱۰ مه ۲۰۲۳)",
+    "img": null,
+    "poster": "./assets/picture/AryanTv_interview.jpg",
+    "videoID": "wqyMQG1P6lo",
+    "text": "توضیح دادم چگونه به‌عنوان کردِ یارسان با تبعیض ساختاری روبه‌رو بوده‌ام، چرا مهاجرت تنها راه بود و چگونه حتی در تبعید تهدید جانی دریافت کرده‌ام؛ هنر را ابزار مقاومت می‌دانم.",
+    "source": {
+      "label": "Youtube",
+      "url": "https://youtu.be/wqyMQG1P6lo"
+    }
+  },
+  {
+    "id": "ArianTvNajmoldin",
+    "title": "برنامه آریان‌تی‌وی با نجم‌الدین غلامی (۲۰۱۹)",
+    "videoID": "sd-luLgFGoM",
+    "text": "حضور در برنامه نوروز تی‌وی برای جشن خواونکار و گفتگو درباره سرکوب هنرمندان یارسان؛ با وجود خطرات، به دفاع از آزادی بیان ادامه داده‌ام.",
+    "source": {
+      "label": "YouTube",
+      "url": "https://www.youtube.com/watch?v=sd-luLgFGoM"
+    }
+  }
+]

--- a/public/data/pdfs.fa.json
+++ b/public/data/pdfs.fa.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "Kiarash Houshmand",
+    "title": "گزارش سالانه ۲۰۲۳ – مرکز فرهنگی یارسان",
+    "pdf": "./assets/pdfs/KiarashHoushmand.pdf",
+    "caption": "گزارشی مفصل از برنامه‌ها و فعالیت‌های سال ۲۰۲۳."
+  },
+  {
+    "id": "Karl Mattias Bergsten",
+    "title": "مانیفست آزادی هنری",
+    "pdf": "./assets/pdfs/KarlMattiasBergsten.pdf",
+    "caption": "سندی درباره دیدگاه ما نسبت به آزادی و نقش تبعید."
+  },
+  {
+    "id": "KARAVAN MUSIKFÖRENING",
+    "title": "KARAVAN_MUSIKFÖRENING",
+    "pdf": "./assets/pdfs/KARAVAN_MUSIKFÖRENING.pdf",
+    "caption": "سندی درباره دیدگاه ما نسبت به آزادی و نقش تبعید."
+  },
+  {
+    "id": "Föreningen_Hoo_Mat",
+    "title": "انجمن هومات",
+    "pdf": "./assets/pdfs/Föreningen_Hoo_Mat.pdf",
+    "caption": "سندی درباره نگاه ما به آزادی و نقش تبعید."
+  },
+  {
+    "id": "alireza_mojallal",
+    "title": "علیرضا مجلل",
+    "pdf": "./assets/pdfs/alireza_mojallal.pdf",
+    "caption": "سندی درباره دیدگاه ما نسبت به آزادی و نقش تبعید."
+  },
+  {
+    "id": "EnamKarami",
+    "title": "انام کرمی",
+    "pdf": "./assets/pdfs/EnamKarami.pdf",
+    "caption": "سندی درباره نگاه ما به آزادی و نقش تبعید."
+  },
+  {
+    "id": "YaresanCulturalInstitute",
+    "title": "مؤسسه فرهنگی یارسان",
+    "pdf": "./assets/pdfs/YaresanCulturalInstitute.pdf",
+    "caption": "سندی درباره دیدگاه ما نسبت به آزادی و نقش تبعید."
+  }
+]

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -19,8 +19,9 @@ header {
 .title-group {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.35rem;
+  text-align: left;
 }
 
 header .print-button {
@@ -55,8 +56,7 @@ header .title {
   font-size: clamp(1.5rem, 4vw, 2.4rem);
   margin: 0;
   font-weight: 600;
-  text-align: center;
-  justify-self: center;
+  text-align: left;
 }
 
 .language-switch {
@@ -186,6 +186,11 @@ header .title {
 [dir='rtl'] header {
   direction: rtl;
   grid-template-columns: auto 1fr auto;
+}
+
+[dir='rtl'] .title-group {
+  align-items: flex-end;
+  text-align: right;
 }
 
 [dir='rtl'] .tabs-container,

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -12,27 +12,27 @@ const tabs = [
   {
     id: 'artiklar',
     label: { sv: 'Artiklar', fa: 'مقالات' },
-    dataPath: { sv: `${DATA_BASE_PATH}/artiklar.json`, fa: `${DATA_BASE_PATH}/artiklar.json` }
+    dataPath: { sv: `${DATA_BASE_PATH}/artiklar.json`, fa: `${DATA_BASE_PATH}/artiklar.fa.json` }
   },
   {
     id: 'bilder',
     label: { sv: 'Bilder', fa: 'تصاویر' },
-    dataPath: { sv: `${DATA_BASE_PATH}/bilder.json`, fa: `${DATA_BASE_PATH}/bilder.json` }
+    dataPath: { sv: `${DATA_BASE_PATH}/bilder.json`, fa: `${DATA_BASE_PATH}/bilder.fa.json` }
   },
   {
     id: 'Performance',
     label: { sv: 'Performance', fa: 'اجراها' },
-    dataPath: { sv: `${DATA_BASE_PATH}/Performance.json`, fa: `${DATA_BASE_PATH}/Performance.json` }
+    dataPath: { sv: `${DATA_BASE_PATH}/Performance.json`, fa: `${DATA_BASE_PATH}/Performance.fa.json` }
   },
   {
     id: 'interview',
     label: { sv: 'Interview', fa: 'مصاحبه‌ها' },
-    dataPath: { sv: `${DATA_BASE_PATH}/interview.json`, fa: `${DATA_BASE_PATH}/interview.json` }
+    dataPath: { sv: `${DATA_BASE_PATH}/interview.json`, fa: `${DATA_BASE_PATH}/interview.fa.json` }
   },
   {
     id: 'pdfs',
     label: { sv: 'Dokuments', fa: 'اسناد' },
-    dataPath: { sv: `${DATA_BASE_PATH}/pdfs.json`, fa: `${DATA_BASE_PATH}/pdfs.json` }
+    dataPath: { sv: `${DATA_BASE_PATH}/pdfs.json`, fa: `${DATA_BASE_PATH}/pdfs.fa.json` }
   }
 ];
 


### PR DESCRIPTION
## Summary
- align the language switch and title group to the edges instead of centering them
- load Persian-specific JSON datasets so Farsi text shows for each tab
- add localized Persian data files for articles, images, performances, interviews, and PDFs

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e55f2732483289870a03f6c5f95f5)