### PR TITLE
Improve RTL alignment for header and sidebar

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -186,11 +186,16 @@ header .title {
 [dir='rtl'] header {
   direction: rtl;
   grid-template-columns: auto 1fr auto;
+  justify-items: start;
 }
 
 [dir='rtl'] .title-group {
   align-items: flex-end;
   text-align: right;
+}
+
+[dir='rtl'] .language-switch {
+  flex-direction: row-reverse;
 }
 
 [dir='rtl'] .tabs-container,

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -83,11 +83,7 @@
   text-decoration: none;
   transition: background-color 0.2s, border 0.2s, transform 0.2s;
   width: 100%;
-  text-align: left;
-}
-
-[dir='rtl'] .sidebar-link {
-  text-align: right;
+  text-align: start;
 }
 
 .sidebar button.sidebar-link {


### PR DESCRIPTION
## Summary
- adjust RTL header layout to honor right-to-left ordering
- flip language switch direction for RTL
- use logical text alignment for sidebar links to better support Persian content

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5a034454832888883a96c2211fa0)