### PR TITLE
Fix RTL sidebar layout

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -171,6 +171,15 @@
   .sidebar.open {
     transform: none;
   }
+
+  [dir='rtl'] .tab-inner {
+    flex-direction: row-reverse;
+  }
+
+  [dir='rtl'] .sidebar {
+    right: 0;
+    left: auto;
+  }
 }
 
 @media print {


### PR DESCRIPTION
## Summary
- reverse the tab layout in RTL views so the sidebar appears on the correct side on wide screens
- keep sticky sidebar positioning anchored correctly in right-to-left mode

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e64ff534c83288f6c4713d62729bf)