### PR TITLE
Move print action to left header

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -19,9 +19,10 @@ header {
 .title-group {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.35rem;
-  text-align: left;
+  text-align: center;
+  justify-self: center;
 }
 
 header .print-button {
@@ -35,7 +36,7 @@ header .print-button {
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
-  justify-self: end;
+  justify-self: left;
 }
 
 header .print-button:hover,
@@ -44,19 +45,18 @@ header .print-button:focus-visible {
   outline: none;
 }
 
-header .logo {
-  justify-self: start;
-  font-size: clamp(0.85rem, 2vw, 1rem);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  color: rgba(255, 255, 255, 0.85);
-}
-
 header .title {
   font-size: clamp(1.5rem, 4vw, 2.4rem);
   margin: 0;
   font-weight: 600;
-  text-align: left;
+  text-align: center;
+}
+
+.print-button--ghost {
+  visibility: hidden;
+  pointer-events: none;
+  user-select: none;
+  justify-self: right;
 }
 
 .language-switch {
@@ -192,12 +192,12 @@ header .title {
 [dir='rtl'] header {
   direction: rtl;
   grid-template-columns: auto 1fr auto;
-  justify-items: start;
+  justify-items: center;
 }
 
 [dir='rtl'] .title-group {
-  align-items: flex-end;
-  text-align: right;
+  align-items: center;
+  text-align: center;
 }
 
 [dir='rtl'] .language-switch {
@@ -224,10 +224,13 @@ header .title {
     padding-top: 1rem;
   }
 
-  header .logo,
   header .title,
   header .print-button {
     justify-self: center;
+  }
+
+  .print-button--ghost {
+    display: none;
   }
 
   header .print-button {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -38,16 +38,14 @@ const tabs = [
 
 const translations = {
   sv: {
-    logo: 'Keyvan Kianian',
-    title: 'Profil',
+    title: 'Keyvan Kianian',
     printButton: 'Skriv ut sidan',
     allList: '☰ Alla listor',
     languageLabel: 'Välj språk',
     languageNames: { sv: 'SV', fa: 'FA' }
   },
   fa: {
-    logo: 'کیوان کیانیان',
-    title: 'پروفایل',
+    title: 'Keyvan Kianian',
     printButton: 'چاپ صفحه',
     allList: '☰ فهرست کامل',
     languageLabel: 'انتخاب زبان',
@@ -113,7 +111,9 @@ const App = () => {
   return (
     <>
       <header>
-        <span className="logo">{localizedStrings.logo}</span>
+        <button type="button" className="print-button" onClick={handlePrint}>
+          {localizedStrings.printButton}
+        </button>
         <div className="title-group">
           <h1 className="title">{localizedStrings.title}</h1>
           <div className="language-switch" aria-label={localizedStrings.languageLabel}>
@@ -129,7 +129,7 @@ const App = () => {
             ))}
           </div>
         </div>
-        <button type="button" className="print-button" onClick={handlePrint}>
+        <button type="button" className="print-button print-button--ghost" aria-hidden="true" tabIndex={-1}>
           {localizedStrings.printButton}
         </button>
       </header>


### PR DESCRIPTION
## Summary
- replace the left-side header label with the print action button text
- adjust header grid and add an invisible placeholder button to keep the title centered
- hide the placeholder on small screens while retaining RTL compatibility

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e66bf26288328b6d09cb33bb13960)