### PR TITLE
Fix RTL sidebar alignment

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -173,7 +173,7 @@
   }
 
   [dir='rtl'] .tab-inner {
-    flex-direction: row-reverse;
+    flex-direction: row;
   }
 
   [dir='rtl'] .sidebar {


### PR DESCRIPTION
## Summary
- adjust RTL desktop layout so the sidebar stays on the right side

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e68573928832886b64b748a5dc698)