### PR TITLE
Fix header alignment and sidebar positioning

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -4,7 +4,7 @@ header {
   line-height: 1.2;
   padding: 1.15rem clamp(1rem, 3vw, 2.5rem);
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   position: fixed;
   top: 0;
@@ -12,17 +12,8 @@ header {
   right: 0;
   z-index: 1000;
   min-height: var(--header-height);
-  gap: 0.75rem;
+  gap: 1rem;
   box-shadow: var(--shadow-soft);
-}
-
-.title-group {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.35rem;
-  text-align: center;
-  justify-self: center;
 }
 
 header .print-button {
@@ -36,7 +27,7 @@ header .print-button {
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
-  justify-self: left;
+  justify-self: start;
 }
 
 header .print-button:hover,
@@ -50,19 +41,10 @@ header .title {
   margin: 0;
   font-weight: 600;
   text-align: center;
-}
-
-.print-button--ghost {
-  visibility: hidden;
-  pointer-events: none;
-  user-select: none;
-  justify-self: right;
+  justify-self: center;
 }
 
 .language-switch {
-  position: absolute;
-  top: 0.6rem;
-  inset-inline-end: clamp(1rem, 3vw, 2.5rem);
   display: inline-flex;
   border: 1px solid rgba(255, 255, 255, 0.35);
   border-radius: 999px;
@@ -70,6 +52,7 @@ header .title {
   background: rgba(255, 255, 255, 0.18);
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.2);
   gap: 0.15rem;
+  justify-self: end;
 }
 
 .language-button {
@@ -191,19 +174,12 @@ header .title {
 
 [dir='rtl'] header {
   direction: rtl;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   justify-items: center;
-}
-
-[dir='rtl'] .title-group {
-  align-items: center;
-  text-align: center;
 }
 
 [dir='rtl'] .language-switch {
   flex-direction: row-reverse;
-  inset-inline-end: auto;
-  inset-inline-start: clamp(1rem, 3vw, 2.5rem);
 }
 
 [dir='rtl'] .tabs-container,
@@ -220,17 +196,16 @@ header .title {
 @media (max-width: 600px) {
   header {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
     text-align: center;
     padding-top: 1rem;
+    gap: 0.65rem;
   }
 
   header .title,
-  header .print-button {
+  header .print-button,
+  .language-switch {
     justify-self: center;
-  }
-
-  .print-button--ghost {
-    display: none;
   }
 
   header .print-button {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -114,24 +114,19 @@ const App = () => {
         <button type="button" className="print-button" onClick={handlePrint}>
           {localizedStrings.printButton}
         </button>
-        <div className="title-group">
-          <h1 className="title">{localizedStrings.title}</h1>
-          <div className="language-switch" aria-label={localizedStrings.languageLabel}>
-            {Object.keys(translations).map((langKey) => (
-              <button
-                key={langKey}
-                type="button"
-                className={`language-button ${language === langKey ? 'active' : ''}`}
-                onClick={() => handleLanguageChange(langKey)}
-              >
-                {localizedStrings.languageNames[langKey] ?? langKey.toUpperCase()}
-              </button>
-            ))}
-          </div>
+        <h1 className="title">{localizedStrings.title}</h1>
+        <div className="language-switch" aria-label={localizedStrings.languageLabel}>
+          {Object.keys(translations).map((langKey) => (
+            <button
+              key={langKey}
+              type="button"
+              className={`language-button ${language === langKey ? 'active' : ''}`}
+              onClick={() => handleLanguageChange(langKey)}
+            >
+              {localizedStrings.languageNames[langKey] ?? langKey.toUpperCase()}
+            </button>
+          ))}
         </div>
-        <button type="button" className="print-button print-button--ghost" aria-hidden="true" tabIndex={-1}>
-          {localizedStrings.printButton}
-        </button>
       </header>
 
       <div className="tabs-container">

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -38,8 +38,8 @@
   width: min(22rem, 85vw);
   max-width: 90%;
   position: fixed;
-  top: 0;
-  left: 0;
+  top: calc(var(--header-height) + var(--tabs-height) + 0.75rem);
+  left: clamp(0.75rem, 3vw, 1.5rem);
   bottom: 0;
   flex-shrink: 0;
   transform: translateX(-100%);
@@ -54,7 +54,7 @@
 
 [dir='rtl'] .sidebar {
   left: auto;
-  right: 0;
+  right: clamp(0.75rem, 3vw, 1.5rem);
   transform: translateX(100%);
 }
 


### PR DESCRIPTION
## Summary
- align header controls and language switch to opposite sides while keeping the title centered
- simplify header layout for both LTR and RTL languages
- reposition the sidebar so it stays within the content frame below the fixed header

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6a2b845c8328971801ac4c0ef5f1)