### PR TITLE
Enhance story card styling

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -108,23 +108,76 @@
 .performance-item,
 .video-item,
 .pdf-panel {
-  background-color: var(--color-surface);
-  border-radius: 1rem;
-  padding: clamp(1.25rem, 2.5vw, 2rem);
-  box-shadow: var(--shadow-soft);
+  position: relative;
+  background: linear-gradient(145deg, rgba(22, 35, 71, 0.025), rgba(22, 35, 71, 0.06)), var(--color-surface);
+  border-radius: 1.1rem;
+  padding: clamp(1.35rem, 2.6vw, 2.2rem);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.15);
   margin: 0;
   scroll-margin-top: calc(var(--header-height) + var(--tabs-height) + 1rem);
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(22, 35, 71, 0.08);
+  overflow: hidden;
+  isolation: isolate;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.performance-item::before,
+.video-item::before,
+.pdf-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 12% 20%, rgba(249, 115, 22, 0.12), transparent 30%),
+    radial-gradient(circle at 85% 10%, rgba(22, 35, 71, 0.08), transparent 28%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.performance-item:hover,
+.video-item:hover,
+.pdf-panel:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 38px rgba(15, 23, 42, 0.22);
+  border-color: rgba(22, 35, 71, 0.15);
 }
 
 .performance-item h2 {
-  margin-top: 0;
-  font-size: clamp(1.25rem, 3vw, 1.9rem);
+  position: relative;
+  margin: 0 0 0.85rem;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  line-height: 1.3;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--color-primary-strong);
+  padding: 0.35rem 0.85rem;
+  background: rgba(22, 35, 71, 0.04);
+  border: 1px solid rgba(22, 35, 71, 0.08);
+  border-radius: 0.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  z-index: 1;
+}
+
+.performance-item h2::before {
+  content: '◆';
+  font-size: 0.9em;
+  color: var(--color-accent);
+  filter: drop-shadow(0 2px 4px rgba(249, 115, 22, 0.35));
 }
 
 .text-content {
-  margin: 1rem 0 1.5rem;
+  position: relative;
+  margin: 1.1rem 0 1.6rem;
   color: var(--color-muted);
+  padding: 1rem 1.15rem;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(22, 35, 71, 0.05);
+  border-radius: 0.85rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  z-index: 1;
 }
 
 .text-content p {


### PR DESCRIPTION
## Summary
- Restyle story cards with layered gradients, accent outlines, and hover elevation to make each entry stand out.
- Emphasize story titles with pill styling, accent icon, and tighter spacing.
- Add padded text blocks to improve readability across languages.

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6d22b1348328a9a81c31a6ab3fd5)