### PR TITLE
Improve overlay transition and gallery reset handling

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -121,11 +121,13 @@ header .title {
   z-index: 1000;
   pointer-events: none;
   transition: opacity 0.3s ease;
+  opacity: 0;
 }
 
 .overlay.show {
   display: block;
   pointer-events: auto;
+  opacity: 1;
 }
 
 .tabs {

--- a/src/components/ImageGallery/ImageGallery.jsx
+++ b/src/components/ImageGallery/ImageGallery.jsx
@@ -16,7 +16,7 @@ const ImageGallery = ({ images, title, language, strings }) => {
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [normalized.length]);
+  }, [normalized]);
 
   if (!normalized.length) return null;
 


### PR DESCRIPTION
## Summary
- Reset the active image in the gallery whenever the available images change
- Add opacity transitions to the overlay for smoother sidebar toggling visuals

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6edec50c8328afd49f1bfe50b2d8)