### PR TITLE
Fix RTL sidebar positioning

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -39,7 +39,8 @@
   width: min(22rem, calc(100vw - (var(--sidebar-gap) * 2)));
   position: fixed;
   top: calc(var(--header-height) + var(--tabs-height) + 0.75rem);
-  inset-inline-start: var(--sidebar-gap);
+  left: var(--sidebar-gap);
+  right: auto;
   bottom: 0;
   flex-shrink: 0;
   transform: translateX(-100%);
@@ -53,8 +54,8 @@
 }
 
 [dir='rtl'] .sidebar {
-  inset-inline-start: auto;
-  inset-inline-end: var(--sidebar-gap);
+  left: auto;
+  right: var(--sidebar-gap);
   transform: translateX(100%);
 }
 
@@ -219,6 +220,7 @@
     max-width: 22rem;
     height: fit-content;
     max-height: calc(100vh - var(--header-height) - var(--tabs-height) - 2rem);
+    right: auto;
   }
 
   .sidebar.open {


### PR DESCRIPTION
## Summary
- anchor the sidebar with physical left/right positioning to keep it inside the viewport when using RTL languages
- maintain correct slide-in behavior for the sidebar toggle in Persian

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef14ed370832881da76d28c6d3aa9)