### PR TITLE
Fix header control alignment and Farsi title

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -14,6 +14,7 @@ header {
   min-height: var(--header-height);
   gap: 1rem;
   box-shadow: var(--shadow-soft);
+  direction: ltr;
 }
 
 header .print-button {
@@ -175,13 +176,16 @@ header .title {
 }
 
 [dir='rtl'] header {
-  direction: rtl;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   justify-items: center;
 }
 
+[dir='rtl'] header .title {
+  direction: rtl;
+}
+
 [dir='rtl'] .language-switch {
-  flex-direction: row-reverse;
+  direction: ltr;
 }
 
 [dir='rtl'] .tabs-container,

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -45,7 +45,7 @@ const translations = {
     languageNames: { sv: 'SV', fa: 'FA' }
   },
   fa: {
-    title: 'Keyvan Kianian',
+    title: 'کیوان کیانیان',
     printButton: 'چاپ صفحه',
     allList: '☰ فهرست کامل',
     languageLabel: 'انتخاب زبان',


### PR DESCRIPTION
## Summary
- keep header controls in consistent positions across languages by enforcing stable header direction
- ensure Farsi title uses localized text

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef23a1da483288bf5b24f88127386)