### PR TITLE
Tighten sidebar spacing in RTL layout

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -12,15 +12,20 @@
 }
 
 .tab-inner {
+  --layout-gap: 1.5rem;
   display: flex;
   width: 100%;
   flex-direction: column;
   align-items: stretch;
-  gap: 1.5rem;
+  gap: var(--layout-gap);
   margin-top: 1.5rem;
   max-width: 80rem;
   margin-left: auto;
   margin-right: auto;
+}
+
+.tabcontent[dir='rtl'] .tab-inner {
+  --layout-gap: clamp(1rem, 2.5vw, 1.75rem);
 }
 
 .content {
@@ -205,9 +210,14 @@
   }
 
   .tab-inner {
+    --layout-gap: 2.5rem;
     flex-direction: row;
     align-items: flex-start;
-    gap: 2.5rem;
+    gap: var(--layout-gap);
+  }
+
+  .tabcontent[dir='rtl'] .tab-inner {
+    --layout-gap: clamp(1.5rem, 2vw, 2rem);
   }
 
   .sidebar {


### PR DESCRIPTION
## Summary
- adjust tab layout gap handling to reduce spacing between sidebar and content for RTL/Farsi
## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef5e61a088328b0f636f8b2dd8d25)