### PR TITLE
Adjust base font sizing for 100% zoom

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,7 @@
 
 html {
   scroll-behavior: smooth;
+  font-size: 90%;
 }
 
 body {


### PR DESCRIPTION
## Summary
- reduce the global base font size to 90% so elements render smaller at default zoom

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef944681883289ab18b590b2e0355)