### PR TITLE
Simplify styling and clean layouts

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,39 +1,36 @@
 header {
-  background: linear-gradient(120deg, #0f172a, #1d3a8a);
+  background: var(--color-primary);
   color: white;
   line-height: 1.2;
-  padding: 1.15rem clamp(1rem, 3vw, 2.5rem);
+  padding: 1rem clamp(1rem, 3vw, 2.5rem);
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  inset: 0 0 auto;
   z-index: 1000;
   min-height: var(--header-height);
   gap: 1rem;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 4px 12px rgba(13, 20, 43, 0.12);
   direction: ltr;
 }
 
 header .print-button {
-  background: rgba(255, 255, 255, 0.15);
+  background: transparent;
   color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.5);
   border-radius: 999px;
-  padding: 0.45rem 1rem;
+  padding: 0.4rem 1rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.25);
   justify-self: start;
 }
 
 header .print-button:hover,
 header .print-button:focus-visible {
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.14);
   outline: none;
 }
 
@@ -47,11 +44,10 @@ header .title {
 
 .language-switch {
   display: inline-flex;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 999px;
   padding: 0.05rem;
-  background: rgba(255, 255, 255, 0.18);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.2);
+  background: rgba(255, 255, 255, 0.15);
   gap: 0.15rem;
   justify-self: end;
 }
@@ -60,9 +56,9 @@ header .title {
   background: transparent;
   color: white;
   border: none;
-  padding: 0.3rem 0.55rem;
-  font-weight: 800;
-  font-size: 0.78rem;
+  padding: 0.35rem 0.6rem;
+  font-weight: 700;
+  font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   border-radius: 999px;
@@ -71,13 +67,13 @@ header .title {
 }
 
 .language-button.active {
-  background: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.9);
   color: #0f172a;
 }
 
 .language-button:not(.active):hover,
 .language-button:not(.active):focus-visible {
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.22);
   outline: none;
 }
 
@@ -86,17 +82,15 @@ header .title {
   top: var(--header-height);
   left: 0;
   right: 0;
-  background-color: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(12px);
+  background-color: #fff;
   z-index: 999;
-  padding: 0.85rem clamp(0.75rem, 4vw, 2rem);
+  padding: 0.75rem clamp(0.75rem, 4vw, 2rem);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.85rem;
+  gap: 0.75rem;
   min-height: var(--tabs-height);
-  box-shadow: 0 1rem 1.5rem rgba(13, 20, 43, 0.1);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .sidebar-toggle {
@@ -108,20 +102,17 @@ header .title {
   cursor: pointer;
   font-weight: 600;
   letter-spacing: 0.03em;
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.18);
 }
 
 .overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(13, 20, 43, 0.7);
+  inset: 0;
+  background: rgba(13, 20, 43, 0.6);
   display: none;
   z-index: 1000;
   pointer-events: none;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.2s ease;
   opacity: 0;
 }
 
@@ -149,30 +140,30 @@ header .title {
 }
 
 .tablink {
-  background-color: rgba(255, 255, 255, 0.85);
-  border: 1px solid transparent;
+  background-color: #fff;
+  border: 1px solid var(--color-border);
   border-radius: 999px;
   padding: 0.45rem clamp(0.5rem, 2vw, 1.25rem);
   font-weight: 600;
   font-size: clamp(0.75rem, 2.5vw, 1rem);
   color: var(--color-primary);
   cursor: pointer;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
-  transition: background-color 0.3s, color 0.3s, border-color 0.3s, transform 0.2s;
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   flex: 0 0 auto;
   white-space: nowrap;
 }
 
-.tablink:hover {
-  transform: translateY(-2px);
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.3);
+.tablink:hover,
+.tablink:focus-visible {
+  background-color: rgba(22, 35, 71, 0.08);
+  border-color: var(--color-primary);
+  outline: none;
 }
 
 .tablink.active {
   background-color: var(--color-primary);
   color: white;
   border-color: var(--color-primary);
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.25);
 }
 
 [dir='rtl'] header {

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -1,8 +1,6 @@
 .tabcontent {
   display: none;
-  padding: calc(var(--header-height) + var(--tabs-height) + 1.5rem)
-    clamp(1.25rem, 6vw, 8rem)
-    3rem;
+  padding: calc(var(--header-height) + var(--tabs-height) + 1.5rem) clamp(1.25rem, 6vw, 3rem) 3rem;
   width: 100%;
   margin: 0 auto;
 }
@@ -38,7 +36,7 @@
 
 .sidebar {
   --sidebar-gap: clamp(0.75rem, 3vw, 1.5rem);
-  background: rgba(255, 255, 255, 0.92);
+  background: #fff;
   padding: 1rem;
   border-radius: var(--radius);
   width: min(22rem, calc(100vw - (var(--sidebar-gap) * 2)));
@@ -55,7 +53,7 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--color-border);
 }
 
 [dir='rtl'] .sidebar {
@@ -81,20 +79,20 @@
   display: block;
   padding: 0.75rem 0.85rem;
   margin-bottom: 0.55rem;
-  background-color: rgba(255, 255, 255, 0.75);
-  border: 1px solid transparent;
+  background-color: #fff;
+  border: 1px solid var(--color-border);
   border-radius: 0.45rem;
   font-weight: 600;
   color: var(--color-primary);
   text-decoration: none;
-  transition: background-color 0.2s, border 0.2s, transform 0.2s;
+  transition: background-color 0.15s, border 0.15s, transform 0.15s;
   width: 100%;
   text-align: start;
 }
 
 .sidebar button.sidebar-link {
   border: none;
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: #fff;
   cursor: pointer;
   font: inherit;
 }
@@ -112,78 +110,40 @@
 }
 
 .performance-item,
-.video-item,
 .pdf-panel {
   position: relative;
-  background: linear-gradient(145deg, rgba(22, 35, 71, 0.025), rgba(22, 35, 71, 0.06)), var(--color-surface);
-  border-radius: 1.1rem;
-  padding: clamp(1.35rem, 2.6vw, 2.2rem);
-  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.15);
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: clamp(1.35rem, 2.6vw, 2rem);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
   margin: 0;
   scroll-margin-top: calc(var(--header-height) + var(--tabs-height) + 1rem);
-  border: 1px solid rgba(22, 35, 71, 0.08);
-  overflow: hidden;
-  isolation: isolate;
+  border: 1px solid var(--color-border);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.performance-item::before,
-.video-item::before,
-.pdf-panel::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(circle at 12% 20%, rgba(249, 115, 22, 0.12), transparent 30%),
-    radial-gradient(circle at 85% 10%, rgba(22, 35, 71, 0.08), transparent 28%);
-  pointer-events: none;
-  z-index: 0;
-}
-
 .performance-item:hover,
-.video-item:hover,
 .pdf-panel:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 24px 38px rgba(15, 23, 42, 0.22);
-  border-color: rgba(22, 35, 71, 0.15);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.16);
 }
 
 .performance-item h2 {
-  position: relative;
   margin: 0 0 0.85rem;
   font-size: clamp(1.35rem, 3vw, 2rem);
   line-height: 1.3;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
   font-weight: 700;
   letter-spacing: 0.01em;
   color: var(--color-primary-strong);
-  padding: 0.35rem 0.85rem;
-  background: rgba(22, 35, 71, 0.04);
-  border: 1px solid rgba(22, 35, 71, 0.08);
-  border-radius: 0.75rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
-  z-index: 1;
-}
-
-.performance-item h2::before {
-  content: '◆';
-  font-size: 0.9em;
-  color: var(--color-accent);
-  filter: drop-shadow(0 2px 4px rgba(249, 115, 22, 0.35));
 }
 
 .text-content {
-  position: relative;
   margin: 1.1rem 0 1.6rem;
   color: var(--color-muted);
   padding: 1rem 1.15rem;
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(22, 35, 71, 0.05);
+  background: #fff;
+  border: 1px solid var(--color-border);
   border-radius: 0.85rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
-  z-index: 1;
 }
 
 .text-content p {
@@ -270,7 +230,6 @@
   }
 
   .performance-item,
-  .video-item,
   .pdf-panel {
     box-shadow: none;
     border: 1px solid rgba(15, 23, 42, 0.15);

--- a/src/style.css
+++ b/src/style.css
@@ -15,10 +15,10 @@
   --color-accent: #f97316;
   --color-surface: #ffffff;
   --color-muted: #5f6d7e;
-  --color-border: #e3e8f2;
-  --color-background: #f5f7fb;
+  --color-border: #d9deea;
+  --color-background: #f7f8fb;
   --radius: 0.75rem;
-  --shadow-soft: 0 20px 35px rgba(13, 20, 43, 0.15);
+  --shadow-soft: 0 8px 18px rgba(13, 20, 43, 0.14);
 }
 
 @media (max-width: 600px) {
@@ -35,8 +35,7 @@ html {
 
 body {
   font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: radial-gradient(circle at top, rgba(249, 115, 22, 0.08), transparent 50%),
-    var(--color-background);
+  background: var(--color-background);
   margin: 0;
   padding: 0;
   color: var(--color-primary-strong);


### PR DESCRIPTION
## Summary
- tone down global colors and shadows to give the layout a cleaner base
- simplify header, tabs, and sidebar styling to remove heavy gradients and clutter
- streamline content cards and text blocks with lighter borders and hover states

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691efcaa61988328b0b27a54326db6f7)