### PR TITLE
Reduce whitespace around PDF viewer

### DIFF
--- a/src/components/PdfViewer/PdfViewer.css
+++ b/src/components/PdfViewer/PdfViewer.css
@@ -4,7 +4,7 @@
 
 .pdf-frame {
   width: 100%;
-  max-width: 65rem;
+  max-width: 100%;
   min-height: clamp(60vh, 70vw, 85vh);
   border: none;
   border-radius: 1rem;

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -17,7 +17,7 @@
   align-items: stretch;
   gap: var(--layout-gap);
   margin-top: 1.5rem;
-  max-width: 80rem;
+  max-width: min(92vw, 105rem);
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- widen tab content container on large screens to cut down unused horizontal space
- let embedded PDFs expand to the full available width inside their panels

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f028edbf48328a3573bd8b912299a)