### PR TITLE
Reduce RTL padding around tab layout

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -11,6 +11,10 @@
   display: block;
 }
 
+.tabcontent[dir='rtl'] {
+  padding-inline: clamp(1rem, 3vw, 3.5rem);
+}
+
 .tab-inner {
   --layout-gap: 1.5rem;
   display: flex;
@@ -26,6 +30,8 @@
 
 .tabcontent[dir='rtl'] .tab-inner {
   --layout-gap: clamp(0.75rem, 1.75vw, 1.35rem);
+  max-width: 100%;
+  margin-inline: 0;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- decrease inline padding for RTL tab content sections
- let RTL tab layout span the full width by removing extra margins

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f2206aa548328920b584b750efa3d)