### PR TITLE
Fix RTL layout spacing and sidebar position

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -30,8 +30,8 @@
 
 .tabcontent[dir='rtl'] .tab-inner {
   --layout-gap: clamp(0.75rem, 1.75vw, 1.35rem);
-  max-width: 100%;
-  margin-inline: 0;
+  max-width: min(92vw, 105rem);
+  margin-inline: auto;
 }
 
 .content {
@@ -243,11 +243,12 @@
     transform: none;
   }
 
-  [dir='rtl'] .tab-inner {
-    flex-direction: row;
+  .tabcontent[dir='rtl'] .tab-inner {
+    flex-direction: row-reverse;
   }
 
-  [dir='rtl'] .sidebar {
+  .tabcontent[dir='rtl'] .sidebar {
+    transform: none;
     right: auto;
     left: auto;
   }


### PR DESCRIPTION
## Summary
- align RTL tab content width with the same centered container sizing used in the LTR layout
- adjust RTL desktop layout so the sidebar stays in view and columns flow naturally

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f25155db0832885289d262ff688a0)