### PR TITLE
Ensure mobile tab bar stacks by default

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -81,6 +81,7 @@ header .title {
   outline: none;
 }
 
+
 .tabs-container {
   position: fixed;
   top: var(--header-height);
@@ -91,12 +92,38 @@ header .title {
   z-index: 999;
   padding: 0.85rem clamp(0.75rem, 4vw, 2rem);
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
   flex-wrap: wrap;
-  align-items: center;
   gap: 0.85rem;
   min-height: var(--tabs-height);
   box-shadow: 0 1rem 1.5rem rgba(13, 20, 43, 0.1);
   border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.sidebar-toggle {
+  width: 100%;
+  text-align: center;
+}
+
+.tabs {
+  width: 100%;
+}
+
+@media (min-width: 769px) {
+  .tabs-container {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .sidebar-toggle {
+    width: auto;
+    text-align: left;
+  }
+
+  .tabs {
+    width: auto;
+  }
 }
 
 .sidebar-toggle {


### PR DESCRIPTION
## Summary
- default the tab bar layout to stacked on small screens so the full list button is always visible
- adjust sidebar toggle and tabs widths to reflow correctly on desktop

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f2a8e85248328b91b7755b5bb7d18)