### PR TITLE
Improve mobile sidebar visibility

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -130,7 +130,13 @@ const App = () => {
       </header>
 
       <div className="tabs-container">
-        <button className="sidebar-toggle" type="button" onClick={toggleSidebar}>
+        <button
+          className="sidebar-toggle"
+          type="button"
+          aria-expanded={sidebarOpen}
+          aria-controls={`sidebar-${activeTab}`}
+          onClick={toggleSidebar}
+        >
           {localizedStrings.allList}
         </button>
         <div className="tabs">

--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -55,13 +55,16 @@
   bottom: 0;
   flex-shrink: 0;
   transform: translateX(-100%);
-  transition: transform 0.3s ease;
-  z-index: 1001;
+  transition: transform 0.3s ease, opacity 0.25s ease;
+  z-index: 1200;
   max-height: 100vh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   box-shadow: var(--shadow-soft);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 [dir='rtl'] .sidebar {
@@ -76,6 +79,9 @@
 
 .sidebar.open {
   transform: translateX(0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 .sidebar nav {
@@ -237,6 +243,9 @@
     height: fit-content;
     max-height: calc(100vh - var(--header-height) - var(--tabs-height) - 2rem);
     right: auto;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 
   .sidebar.open {

--- a/src/components/TabPanel/TabPanel.jsx
+++ b/src/components/TabPanel/TabPanel.jsx
@@ -204,7 +204,7 @@ const TabPanel = ({ tab, isActive, isSidebarOpen, closeSidebar, language }) => {
       dir={direction}
     >
       <div className="tab-inner">
-        <aside className={`sidebar ${isActive && isSidebarOpen ? 'open' : ''}`}>
+        <aside id={`sidebar-${tab.id}`} className={`sidebar ${isActive && isSidebarOpen ? 'open' : ''}`}>
           {loading && <p>{localizedText.loadingList}</p>}
           {error && <p role="alert">{localizedText.loadError}</p>}
           {!loading && !error && (


### PR DESCRIPTION
## Summary
- add accessibility attributes linking the sidebar toggle to the active tab's sidebar
- give each sidebar a stable id for control and anchoring
- adjust sidebar styling so it stays above overlays on mobile and only becomes interactive when opened while remaining visible on desktop

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f33bbe9008328965af667416d4318)