### PR TITLE
Keep header controls inline on small screens

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -244,21 +244,10 @@ header .title {
 
 @media (max-width: 600px) {
   header {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     text-align: center;
     padding-top: 1rem;
-    gap: 0.65rem;
-  }
-
-  header .title,
-  header .print-button,
-  .language-switch {
-    justify-self: center;
-  }
-
-  header .print-button {
-    width: 100%;
+    gap: 0.75rem;
   }
 
   .tabs-container {


### PR DESCRIPTION
## Summary
- keep header controls on a single row at mobile sizes to avoid excessive header height
- adjust spacing to maintain alignment while preventing components from stacking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f36b910c883289b455bd99333d7e0)