### PR TITLE
Ensure gallery images appear in print view

### DIFF
--- a/src/components/ImageGallery/ImageGallery.css
+++ b/src/components/ImageGallery/ImageGallery.css
@@ -52,3 +52,21 @@
     border-radius: 1rem;
   }
 }
+
+@media print {
+  .image-gallery {
+    page-break-inside: avoid;
+  }
+
+  .main-image {
+    max-height: none;
+    background: transparent;
+    box-shadow: none;
+    display: block !important;
+    visibility: visible !important;
+  }
+
+  .thumbnail-row {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add print-specific styles so main gallery images remain visible in print view
- hide thumbnail strip during printing and remove visual effects that can suppress printed images

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922382b462c8328ae1f678a92c6fd7e)