### PR TITLE
Ensure images appear in printed gallery

### DIFF
--- a/src/components/ImageGallery/ImageGallery.css
+++ b/src/components/ImageGallery/ImageGallery.css
@@ -2,6 +2,10 @@
   margin: 1.25rem 0;
 }
 
+.print-gallery {
+  display: none;
+}
+
 .main-image {
   width: 100%;
   border-radius: 1rem;
@@ -59,11 +63,22 @@
   }
 
   .main-image {
-    max-height: none;
-    background: transparent;
+    display: none !important;
+  }
+
+  .print-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .print-image {
+    width: 100%;
+    height: auto;
+    border-radius: 0.75rem;
     box-shadow: none;
-    display: block !important;
-    visibility: visible !important;
+    object-fit: contain;
+    background: transparent;
   }
 
   .thumbnail-row {

--- a/src/components/ImageGallery/ImageGallery.jsx
+++ b/src/components/ImageGallery/ImageGallery.jsx
@@ -31,6 +31,17 @@ const ImageGallery = ({ images, title, language, strings }) => {
         className="main-image"
         dir={language === 'fa' ? 'rtl' : 'ltr'}
       />
+      <div className="print-gallery" aria-hidden="true">
+        {normalized.map((src, index) => (
+          <img
+            key={`${src}-${index}`}
+            src={src}
+            alt={copy.galleryImageAlt?.(title, index + 1) || `${title || 'Gallery'} – bild ${index + 1}`}
+            className="print-image"
+            loading="eager"
+          />
+        ))}
+      </div>
       {normalized.length > 1 && (
         <div className="thumbnail-row" role="list">
           {normalized.map((src, index) => (


### PR DESCRIPTION
## Summary
- render a print-only gallery so all images are included when printing
- add print-specific styles to show the gallery images in a grid while hiding thumbnails and interactive views

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224087884c83288eeac82f898d88b3)