### PR TITLE
Add contact tab with social media links

### DIFF
--- a/public/data/contact.fa.json
+++ b/public/data/contact.fa.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "contact",
+    "title": "شبکه‌های اجتماعی و راه‌های تماس",
+    "text": "<p>برای دنبال کردن موسیقی، اجراها و به‌روزرسانی‌های روزانه من در شبکه‌های اجتماعی همراه باشید. برای همکاری، رزرو اجرا یا پرسش، از راه‌های زیر در تماس باشید.</p><ul><li><strong>اینستاگرام:</strong> <a href=\"https://www.instagram.com/keyvan.kianian.official\" target=\"_blank\" rel=\"noreferrer\">@keyvan.kianian.official</a></li><li><strong>فیسبوک:</strong> <a href=\"https://www.facebook.com/profile.php?id=61563329726258\" target=\"_blank\" rel=\"noreferrer\">Keyvan Kianian</a></li><li><strong>یوتیوب:</strong> <a href=\"https://www.youtube.com/@KeyvanKianian\" target=\"_blank\" rel=\"noreferrer\">@KeyvanKianian</a></li><li><strong>تلگرام:</strong> <a href=\"https://t.me/keyvankianian\" target=\"_blank\" rel=\"noreferrer\">t.me/keyvankianian</a></li></ul><p>برای هماهنگی کنسرت، کارگاه یا مصاحبه: <a href=\"mailto:keyvan.kianian.music@gmail.com\">keyvan.kianian.music@gmail.com</a>.</p>"
+  }
+]

--- a/public/data/contact.json
+++ b/public/data/contact.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "contact",
+    "title": "Följ och kontakta mig",
+    "text": "<p>Du kan följa min musik, mina framträdanden och vardagliga uppdateringar på sociala medier. Hör gärna av dig för samarbeten, bokningar eller frågor.</p><ul><li><strong>Instagram:</strong> <a href=\"https://www.instagram.com/keyvan.kianian.official\" target=\"_blank\" rel=\"noreferrer\">@keyvan.kianian.official</a></li><li><strong>Facebook:</strong> <a href=\"https://www.facebook.com/profile.php?id=61563329726258\" target=\"_blank\" rel=\"noreferrer\">Keyvan Kianian</a></li><li><strong>YouTube:</strong> <a href=\"https://www.youtube.com/@KeyvanKianian\" target=\"_blank\" rel=\"noreferrer\">@KeyvanKianian</a></li><li><strong>Telegram:</strong> <a href=\"https://t.me/keyvankianian\" target=\"_blank\" rel=\"noreferrer\">t.me/keyvankianian</a></li></ul><p>För att boka konserter, workshops eller intervjuer: <a href=\"mailto:keyvan.kianian.music@gmail.com\">keyvan.kianian.music@gmail.com</a>.</p>"
+  }
+]

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -33,6 +33,11 @@ const tabs = [
     id: 'pdfs',
     label: { sv: 'Dokuments', fa: 'اسناد' },
     dataPath: { sv: `${DATA_BASE_PATH}/pdfs.json`, fa: `${DATA_BASE_PATH}/pdfs.fa.json` }
+  },
+  {
+    id: 'contact',
+    label: { sv: 'Kontakt', fa: 'ارتباط' },
+    dataPath: { sv: `${DATA_BASE_PATH}/contact.json`, fa: `${DATA_BASE_PATH}/contact.fa.json` }
   }
 ];
 


### PR DESCRIPTION
## Summary
- add a new Contact tab for both Swedish and Persian views with social media and booking details
- load contact data from new localized JSON files alongside existing tabs

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922421437c48328bb243e9b421d0f30)