### PR TITLE
Preload print gallery images for printing

### DIFF
--- a/src/components/ImageGallery/ImageGallery.css
+++ b/src/components/ImageGallery/ImageGallery.css
@@ -1,5 +1,17 @@
 .image-gallery {
   margin: 1.25rem 0;
+  position: relative;
+}
+
+.print-gallery {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .main-image {
@@ -59,11 +71,29 @@
   }
 
   .main-image {
-    max-height: none;
-    background: transparent;
+    display: none !important;
+  }
+
+  .print-gallery {
+    position: static;
+    height: auto;
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .print-image {
+    width: 100%;
+    height: auto;
+    border-radius: 0.75rem;
     box-shadow: none;
-    display: block !important;
-    visibility: visible !important;
+    object-fit: contain;
+    background: transparent;
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 
   .thumbnail-row {

--- a/src/components/ImageGallery/ImageGallery.jsx
+++ b/src/components/ImageGallery/ImageGallery.jsx
@@ -31,6 +31,17 @@ const ImageGallery = ({ images, title, language, strings }) => {
         className="main-image"
         dir={language === 'fa' ? 'rtl' : 'ltr'}
       />
+      <div className="print-gallery" aria-hidden="true">
+        {normalized.map((src, index) => (
+          <img
+            key={`${src}-${index}`}
+            src={src}
+            alt={copy.galleryImageAlt?.(title, index + 1) || `${title || 'Gallery'} – bild ${index + 1}`}
+            className="print-image"
+            loading="eager"
+          />
+        ))}
+      </div>
       {normalized.length > 1 && (
         <div className="thumbnail-row" role="list">
           {normalized.map((src, index) => (


### PR DESCRIPTION
## Summary
- keep print-gallery images rendered off-screen so they preload before entering print view
- restore print layout styles to reveal the gallery grid during printing while preventing image breakage

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224087884c83288eeac82f898d88b3)