### PR TITLE
Allow printed items to span multiple pages

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -290,6 +290,7 @@
   .pdf-panel {
     box-shadow: none;
     border: 1px solid rgba(15, 23, 42, 0.15);
-    page-break-inside: avoid;
+    page-break-inside: auto;
+    break-inside: auto;
   }
 }


### PR DESCRIPTION
## Summary
- allow tab panel items to break across pages during printing so long stories can span multiple sheets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692246386cfc832894e51acb00716458)