### PR TITLE
Adjust print image sizing

### DIFF
--- a/src/components/ImageGallery/ImageGallery.css
+++ b/src/components/ImageGallery/ImageGallery.css
@@ -85,13 +85,14 @@
     opacity: 1;
     pointer-events: auto;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.65rem;
   }
 
   .print-image {
     width: 100%;
     height: auto;
+    max-height: 200px;
     border-radius: 0.75rem;
     box-shadow: none;
     object-fit: contain;


### PR DESCRIPTION
## Summary
- reduce printed gallery image dimensions by shrinking grid columns and capping height
## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692445f2ccb88328ab2d7762ef189aca)