### PR TITLE
Ensure printed stories keep images together

### DIFF
--- a/src/components/TabPanel/TabPanel.css
+++ b/src/components/TabPanel/TabPanel.css
@@ -290,7 +290,7 @@
   .pdf-panel {
     box-shadow: none;
     border: 1px solid rgba(15, 23, 42, 0.15);
-    page-break-inside: auto;
-    break-inside: auto;
+    page-break-inside: avoid;
+    break-inside: avoid;
   }
 }


### PR DESCRIPTION
## Summary
- prevent page breaks inside printed content panels so story text stays with its images

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692448cc78b48328a4a781ace9590683)