### PR TITLE
Show video posters when printing

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -6,7 +6,8 @@
 }
 
 .video-section video,
-.video-container {
+.video-container,
+.video-wrapper {
   border-radius: 1rem;
   overflow: hidden;
   border: 1px solid rgba(22, 35, 71, 0.08);
@@ -44,4 +45,27 @@
   height: min(60vh, 32rem);
   max-width: 100%;
   border: none;
+}
+
+.video-poster-print {
+  display: none;
+}
+
+@media print {
+  .video-wrapper {
+    border: none;
+    box-shadow: none;
+  }
+
+  .video-wrapper video {
+    display: none;
+  }
+
+  .video-poster-print {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    border-radius: 1rem;
+  }
 }

--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -32,10 +32,16 @@ const VideoPlayer = ({ videoID, video, poster, title, language, strings }) => {
       )}
 
       {normalizedVideos.map((src) => (
-        <video key={src} controls poster={poster || undefined} preload="metadata">
-          <source src={src} />
-          {copy.videoFallback}
-        </video>
+        <div className="video-wrapper" key={src}>
+          <video controls poster={poster || undefined} preload="metadata">
+            <source src={src} />
+            {copy.videoFallback}
+          </video>
+
+          {poster ? (
+            <img className="video-poster-print" src={poster} alt={copy.videoTitle?.(title)} />
+          ) : null}
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap videos with a print-friendly container that can display poster images
- add print styles to hide video playback UI and show the poster when printing

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692449f51ce08328b5f7abd9dd0eacf2)