### PR TITLE
Show video poster when printing

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -61,6 +61,17 @@
     display: none;
   }
 
+  .video-container {
+    border: none;
+    box-shadow: none;
+  }
+
+  .video-container iframe,
+  .video-container object,
+  .video-container embed {
+    display: none;
+  }
+
   .video-poster-print {
     display: block;
     width: 100%;

--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -28,6 +28,10 @@ const VideoPlayer = ({ videoID, video, poster, title, language, strings }) => {
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
           ></iframe>
+
+          {poster ? (
+            <img className="video-poster-print" src={poster} alt={copy.videoTitle?.(title)} />
+          ) : null}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- hide video iframes during print and show the provided poster image instead
- include poster image alongside embedded YouTube videos for print-only rendering

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244ef2eca88328bd6fee5bc6a3d63b)