### PR TITLE
Add poster preview for embedded videos

### DIFF
--- a/src/components/TabPanel/TabPanel.jsx
+++ b/src/components/TabPanel/TabPanel.jsx
@@ -18,6 +18,7 @@ const textContent = {
     galleryImageAlt: (title, index) => `${title || 'Gallery'} – bild ${index}`,
     galleryPreviewAlt: (title, index) => `${title || 'Gallery'} – förhandsvisning ${index}`,
     videoTitle: (title) => title || 'Video från YouTube',
+    playVideo: (title) => `Spela ${title || 'videon'}`,
     videoFallback: 'Din webbläsare stödjer inte video-taggen.'
   },
   fa: {
@@ -32,6 +33,7 @@ const textContent = {
     galleryImageAlt: (title, index) => `${title || 'گالری'} – تصویر ${index}`,
     galleryPreviewAlt: (title, index) => `${title || 'گالری'} – پیش‌نمایش ${index}`,
     videoTitle: (title) => title || 'ویدیو از یوتیوب',
+    playVideo: (title) => `پخش ${title || 'ویدیو'}`,
     videoFallback: 'مرورگر شما از پخش ویدیو پشتیبانی نمی‌کند.'
   }
 };

--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -22,6 +22,47 @@
   max-width: 100%;
 }
 
+.video-preview {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 1px solid rgba(22, 35, 71, 0.08);
+  box-shadow: var(--shadow-soft);
+  border-radius: 1rem;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+}
+
+.video-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.video-preview-cta {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.45) 100%);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  padding: 1rem 1.5rem;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.video-preview:hover .video-preview-cta,
+.video-preview:focus-visible .video-preview-cta {
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.6) 100%);
+  transform: scale(1.01);
+}
+
 .video-container iframe,
 .video-container object,
 .video-container embed {

--- a/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/VideoPlayer/VideoPlayer.jsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import './VideoPlayer.css';
 
 const fallbackStrings = {
   videoTitle: (itemTitle) => itemTitle || 'Video från YouTube',
+  playVideo: (itemTitle) => `Spela ${itemTitle || 'videon'}`,
   videoFallback: 'Din webbläsare stödjer inte video-taggen.'
 };
 
@@ -15,24 +16,36 @@ const VideoPlayer = ({ videoID, video, poster, title, language, strings }) => {
 
   const copy = strings || fallbackStrings;
   const direction = language === 'fa' ? 'rtl' : 'ltr';
+  const [showEmbed, setShowEmbed] = useState(!poster);
+
+  const shouldShowPosterPreview = Boolean(videoID && poster && !showEmbed);
 
   if (!videoID && !normalizedVideos.length) return null;
 
   return (
     <div className="video-section" dir={direction}>
       {videoID && (
-        <div className="video-container">
-          <iframe
-            src={`https://www.youtube.com/embed/${videoID}`}
-            title={copy.videoTitle?.(title)}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          ></iframe>
+        <>
+          {shouldShowPosterPreview ? (
+            <button type="button" className="video-preview" onClick={() => setShowEmbed(true)}>
+              <img src={poster} alt={copy.videoTitle?.(title)} loading="lazy" />
+              <span className="video-preview-cta">{copy.playVideo?.(title)}</span>
+            </button>
+          ) : (
+            <div className="video-container">
+              <iframe
+                src={`https://www.youtube.com/embed/${videoID}`}
+                title={copy.videoTitle?.(title)}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              ></iframe>
 
-          {poster ? (
-            <img className="video-poster-print" src={poster} alt={copy.videoTitle?.(title)} />
-          ) : null}
-        </div>
+              {poster ? (
+                <img className="video-poster-print" src={poster} alt={copy.videoTitle?.(title)} />
+              ) : null}
+            </div>
+          )}
+        </>
       )}
 
       {normalizedVideos.map((src) => (


### PR DESCRIPTION
## Summary
- add a poster-based preview step before loading embedded YouTube videos
- style the poster preview with a play CTA while keeping printable poster support
- extend localized video copy with a play label in Swedish and Persian

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692467fe880c832882b6f19227a014fb)