### PR TITLE
Adjust print styling for video previews

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -122,4 +122,14 @@
     object-fit: cover;
     border-radius: 1rem;
   }
+
+  .video-preview {
+    border: none;
+    box-shadow: none;
+    cursor: default;
+  }
+
+  .video-preview-cta {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
- remove print overlay text from video preview posters and drop extra styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246d46c7a0832896aca379063a5da4)